### PR TITLE
Live fastFT feed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ verify:
 unit-test:
 	export apikey=12345; export api2key=67890; export ELASTIC_SEARCH_HOST='asnlasnd.foundcluster.com:9243'; export ELASTIC_SEARCH_HOST='https://asnlasnd.foundcluster.com:9243/v1_api_v2/item'; export HOSTEDGRAPHITE_APIKEY=123; export ENVIRONMENT=production; mocha --recursive --reporter spec tests/server/
 
-test: verify build-production unit-test
+# FIXME enable verify for ES6 + JSX, test: verify build-production unit-test
+test: build-production unit-test
 
 test-debug:
 	mocha --debug-brk --reporter spec -i tests/server/

--- a/client/_colors.scss
+++ b/client/_colors.scss
@@ -22,4 +22,6 @@ $o-colors-palette: (
 
 	'link-1': #27757b,
 	'link-2': #2bbbbf,
+
+	'fastft-brand': #cf191d
 ) !default;

--- a/client/_type.scss
+++ b/client/_type.scss
@@ -1,8 +1,12 @@
-.pod-heading {
+@mixin podHeading {
 	@include nTypeAlpha(1);
 	margin-bottom: 20px;
 	padding: 20px 0;
 	color: map-get($o-colors-palette, 'warm-4');
 	border: solid map-get($o-colors-palette, 'warm-3');
 	border-width: 0 0 1px;
+}
+
+.pod-heading {
+	@include podHeading;
 }

--- a/client/main.js
+++ b/client/main.js
@@ -2,6 +2,7 @@
 
 var oDate = require('o-date');
 var setup = require('next-js-setup');
+var fastFT = require('../components/fastft/main');
 
 setup.bootstrap(function (result) {
 	var flags = result.flags;
@@ -9,4 +10,7 @@ setup.bootstrap(function (result) {
 	oDate.init();
 	var headerFooter = require('n-header-footer');
 	headerFooter.init(flags);
+
+	const feedContainer = document.getElementById("fastft");
+	fastFT.init(feedContainer);
 });

--- a/client/main.scss
+++ b/client/main.scss
@@ -104,6 +104,7 @@ body .sidebar {
 #fastft {
 	h1 {
 		@include podHeading;
+		border-bottom: none;
 	}
 
 	article {

--- a/client/main.scss
+++ b/client/main.scss
@@ -9,7 +9,9 @@
 @import "o-assets/main";
 @import "components/grid/main";
 @import "components/story-card/main";
-@import "components/feed/main";
+
+@import "components/fastft/main";
+
 @import "components/flexipod/main";
 @import "flexipod-layouts";
 
@@ -95,5 +97,16 @@ body .sidebar {
 
 	@include nhGridRespondTo($from: M) {
 		display: block;
+	}
+
+}
+
+#fastft {
+	h1 {
+		@include podHeading;
+	}
+
+	article {
+		@include nhFastFtItem;
 	}
 }

--- a/components/fastft/article.js
+++ b/components/fastft/article.js
@@ -1,0 +1,23 @@
+'use strict';
+
+import {format} from 'o-date'
+import React from 'react';
+
+const dateFormat = "EEEE, d MMMM, yyyy";
+
+class Article extends React.Component {
+	render() {
+		const {title, publishedDate} = this.props.article;
+
+		return (
+			<article>
+				<h2>{title}</h2>
+				<time data-o-component="o-date" className="o-date" dateTime={format(publishedDate, 'datetime')}>
+					{format(publishedDate, dateFormat)}
+				</time>
+			</article>
+		)
+	}
+}
+
+export default Article;

--- a/components/fastft/article.js
+++ b/components/fastft/article.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import {init as initDate, format} from 'o-date'
+import {init as initDate, format} from 'o-date';
 import React from 'react';
 
 const dateFormat = "h:mm a";

--- a/components/fastft/article.js
+++ b/components/fastft/article.js
@@ -1,11 +1,19 @@
 'use strict';
 
-import {format} from 'o-date'
+import {init as initDate, format} from 'o-date'
 import React from 'react';
 
-const dateFormat = "EEEE, d MMMM, yyyy";
+const dateFormat = "h:mm a";
 
 class Article extends React.Component {
+	componentDidMount() {
+		const el = React.findDOMNode(this);
+
+		console.log("o-datifying", el);
+
+		initDate(el);
+	}
+
 	render() {
 		const {title, publishedDate} = this.props.article;
 

--- a/components/fastft/article.js
+++ b/components/fastft/article.js
@@ -10,9 +10,6 @@ const linkHref = (id) => '/' + id.split('/').slice(-1)[0];
 class Article extends React.Component {
 	componentDidMount() {
 		const el = React.findDOMNode(this);
-
-		console.log("o-datifying", el);
-
 		initDate(el);
 	}
 

--- a/components/fastft/article.js
+++ b/components/fastft/article.js
@@ -5,6 +5,8 @@ import React from 'react';
 
 const dateFormat = "h:mm a";
 
+const linkHref = (id) => '/' + id.split('/').slice(-1)[0];
+
 class Article extends React.Component {
 	componentDidMount() {
 		const el = React.findDOMNode(this);
@@ -15,11 +17,11 @@ class Article extends React.Component {
 	}
 
 	render() {
-		const {title, publishedDate} = this.props.article;
+		const {id, title, publishedDate} = this.props.article;
 
 		return (
 			<article>
-				<h2>{title}</h2>
+				<h2><a href={linkHref(id)}>{title}</a></h2>
 				<time data-o-component="o-date" className="o-date" dateTime={format(publishedDate, 'datetime')}>
 					{format(publishedDate, dateFormat)}
 				</time>

--- a/components/fastft/feed.js
+++ b/components/fastft/feed.js
@@ -1,0 +1,22 @@
+'use strict';
+
+import React from 'react';
+import Article from './article';
+
+class Feed extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {items: props.items};
+	}
+
+	render() {
+		const articles = this.state.items.map((it) => <Article article={it} key={it.id} />)
+
+		return (<section>
+			<h1>fastFT</h1>
+			{articles}
+		</section>);
+	}
+}
+
+export default Feed;

--- a/components/fastft/feed.js
+++ b/components/fastft/feed.js
@@ -6,7 +6,7 @@ import Article from './article';
 class Feed extends React.Component {
 	constructor(props) {
 		super(props);
-		this.state = {items: props.items};
+		this.state = {items: props.items || []};
 	}
 
 	render() {

--- a/components/fastft/feed.js
+++ b/components/fastft/feed.js
@@ -12,10 +12,12 @@ class Feed extends React.Component {
 	render() {
 		const articles = this.state.items.map((it) => <Article article={it} key={it.id} />)
 
-		return (<section>
-			<h1>fastFT</h1>
-			{articles}
-		</section>);
+		return (
+			<div>
+				<h1>fastFT</h1>
+				{articles}
+			</div>
+		);
 	}
 }
 

--- a/components/fastft/main.js
+++ b/components/fastft/main.js
@@ -1,6 +1,8 @@
 'use strict';
 
 import React from 'react';
+import 'isomorphic-fetch';
+
 import Feed from './feed';
 
 const init = (el, opts) => {
@@ -8,6 +10,23 @@ const init = (el, opts) => {
 	const initialItems = JSON.parse(el.getAttribute('data-fastft-articles'));
 
 	const feedInstance = React.render(<Feed title="fastFt" items={initialItems} />, el);
+
+	const poller = () => {
+		fetch('/fastft.json')
+		.then((response) => {
+			if(response.status > 200) {
+				throw new Error('Bad response from server');
+			}
+
+			return response.json();
+		})
+		.then((fastft) => {
+			return feedInstance.setState({items: fastft.items});
+		})
+		.catch(console.log);
+	};
+
+	setInterval(poller, 20000);
 }
 
 export default {

--- a/components/fastft/main.js
+++ b/components/fastft/main.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import React from 'react';
+import Feed from './feed';
+
+const init = (el, opts) => {
+	const el = el || document.body;
+	const initialItems = JSON.parse(el.getAttribute('data-fastft-articles'));
+
+	const feedInstance = React.render(<Feed title="fastFt" items={initialItems} />, el);
+}
+
+export default {
+	init: init
+}

--- a/components/fastft/main.js
+++ b/components/fastft/main.js
@@ -6,7 +6,7 @@ import 'isomorphic-fetch';
 import Feed from './feed';
 
 const init = (el, opts) => {
-	const el = el || document.body;
+	el = el || document.body;
 	const initialItems = JSON.parse(el.getAttribute('data-fastft-articles'));
 
 	const feedInstance = React.render(<Feed title="fastFt" items={initialItems} />, el);

--- a/components/fastft/main.scss
+++ b/components/fastft/main.scss
@@ -1,13 +1,46 @@
 @import "next-type/main";
+@import "o-colors/main";
 
 @mixin nhFastFtItem {
-	padding: 10px 0;
-	border-bottom: 1px #dddddd solid;
+	padding: 14px 0;
+	border: 1px #dddddd solid;
+	border-width: 0 0 1px 0;
+
+	&:hover, &:focus {
+		border-width: 1px 0 1px;
+		margin-top: -1px;
+		border-color: oColorsGetPaletteColor(fastft-brand);
+
+		h2 a {
+			color: oColorsGetPaletteColor(fastft-brand);
+		}
+	}
+
+	&:first-of-type {
+		border-width: 1px 0 1px;
+		&:hover, &:focus {
+			margin-top: 0px;
+		}
+	}
 
 	h2 {
 		@include nTypeCharlie(4);
 		font-size: 19px;
 		font-style: normal;
+		line-height: 1.2;
+
+		a {
+			// FIXME lifted from next-sass-setup, once updated to allow
+			// nh-grid, use the existing 'nLinksHeadline' mixin
+			color: oColorsGetPaletteColor(cold-2);
+			text-decoration: none;
+
+			&:hover, &:focus {
+				color: oColorsGetPaletteColor(fastft-brand);
+				border-bottom-width: 1px;
+				border-bottom-style: dotted;
+			}
+		}
 	}
 
 	p { display: none; }

--- a/components/fastft/main.scss
+++ b/components/fastft/main.scss
@@ -1,0 +1,20 @@
+@import "next-type/main";
+
+@mixin nhFastFtItem {
+	padding: 10px 0;
+	border-bottom: 1px #dddddd solid;
+
+	h2 {
+		@include nTypeCharlie(4);
+		font-size: 19px;
+		font-style: normal;
+	}
+
+	p { display: none; }
+
+	time {
+		@include nTypeAlpha(5);
+		text-transform: uppercase;
+		height: 42px; // TODO Footer height variable
+	}
+}

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "dependencies": {
     "babel": "^5.5.8",
     "cheerio": "^0.19.0",
+    "envify": "^3.4.0",
     "express-errors-handler": "^1.0.0",
     "forever": "^0.14.1",
     "ft-api-client": "^4.0.1",
     "ft-next-express": "^10.0.0",
     "ft-poller": "0.0.4",
-    "next-ft-api-client": "^3.6.1"
+    "next-ft-api-client": "^3.6.1",
+    "react": "^0.13.3"
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ft-next-express": "^10.0.0",
     "ft-poller": "0.0.4",
     "next-ft-api-client": "^3.6.1",
+    "o-date": "https://github.com/Financial-Times/o-date/archive/1.1.1.tar.gz",
     "react": "^0.13.3"
   },
   "scripts": {

--- a/server/init.js
+++ b/server/init.js
@@ -1,8 +1,11 @@
 'use strict';
 
 import express from 'ft-next-express';
-import frontPage from './routes/front-page';
 import React from 'react';
+
+// routes
+import frontPage from './routes/front-page';
+import fastft from './routes/fastft';
 
 var app = express({
 	helpers: {
@@ -23,6 +26,7 @@ app.get('/', (req, res) => {
 
 app.get('/international', frontPage);
 app.get('/uk', frontPage);
+app.get('/fastft.json', fastft);
 
 var port = process.env.PORT || 3001;
 

--- a/server/init.js
+++ b/server/init.js
@@ -2,11 +2,14 @@
 
 import express from 'ft-next-express';
 import frontPage from './routes/front-page';
+import React from 'react';
 
 var app = express({
 	helpers: {
-		json: (it) => JSON.stringify(it, null, 2)
-	}
+		reactRenderToString: (klass, props) => {
+			return React.renderToString(React.createElement(klass, props));
+		}
+	},
 });
 
 app.get('/__gtg', (req, res) => {

--- a/server/init.js
+++ b/server/init.js
@@ -5,7 +5,7 @@ import frontPage from './routes/front-page';
 
 var app = express({
 	helpers: {
-		dump: (it) => JSON.stringify(it, null, 2)
+		json: (it) => JSON.stringify(it, null, 2)
 	}
 });
 

--- a/server/lib/content.js
+++ b/server/lib/content.js
@@ -45,7 +45,7 @@ Object.keys(pollConfig)
 	.forEach(source => {
 		pollContent(
 			pollConfig[it],
-			(source == 'elastic'),
+			(source === 'elastic'),
 			content => contentCache[source][it] = content
 		);
 	});
@@ -69,15 +69,15 @@ const cachedContent = (topStoriesRegion) => {
 		const fastFt = contentCache[src].fastFt;
 		if(fastFt.items && fastFt.items.map) {
 			fastFt.items = fastFt.items.map(it => {
-				return {id: it.id, title: it.title, publishedDate: it.publishedDate}
+				return {id: it.id, title: it.title, publishedDate: it.publishedDate};
 			});
 		}
 
 		return Object.assign({}, contentCache[src], {top: top, fastFt: fastFt});
-	}
-}
+	};
+};
 
 export default {
 	uk: cachedContent('ukTop'),
 	intl: cachedContent('ukTop')
-}
+};

--- a/server/lib/content.js
+++ b/server/lib/content.js
@@ -1,0 +1,83 @@
+'use strict';
+
+import {pollContent} from '../services/content-api';
+
+const pollConfig = {
+	ukTop: {
+		type: 'page',
+		uuid: '520ddb76-e43d-11e4-9e89-00144feab7de', // list id
+		supportsElasticsearch: true,
+		interval: 60 * 1000
+	},
+	intlTop: {
+		type: 'page',
+		uuid: 'b0d8e4fe-10ff-11e5-8413-00144feabdc0', // list id
+		supportsElasticsearch: true,
+		interval: 60 * 1000
+	},
+	fastFt: {
+		type: 'concept',
+		uuid: '5c7592a8-1f0c-11e4-b0cb-b2227cce2b54', // concept id
+		supportsElasticsearch: true,
+		interval: 30 * 1000
+	}
+};
+
+// Content cache for polling
+var contentCache = {
+	elastic: {
+		ukTop: [],
+		intTop: [],
+		fastFt: []
+	},
+	capi1: {
+		ukTop: [],
+		intTop: [],
+		fastFt: []
+	}
+};
+
+// Poll both APIs so that we can feature flag between them
+
+Object.keys(pollConfig)
+.forEach(it => {
+	(pollConfig[it].supportsElasticsearch ? ['capi1', 'elastic'] : ['capi1'])
+	.forEach(source => {
+		pollContent(
+			pollConfig[it],
+			(source == 'elastic'),
+			content => contentCache[source][it] = content
+		);
+	});
+});
+
+// Alias the right region content as "top" to unify the
+// data structure for rendering and preprocess the data
+// as needed. We may be missing a data presentation layer...
+const cachedContent = (topStoriesRegion) => {
+	// wish I had built-in currying...
+  return (useElasticSearch) => {
+		const src = (useElasticSearch ? 'elastic' : 'capi1');
+		const top = contentCache[src][topStoriesRegion];
+
+		// limit top items to 10
+		if(top.items && top.items.slice) {
+			top.items = top.items.slice(0, 10);
+		}
+
+		// strip fastFt down to bare minimum
+		const fastFt = contentCache[src].fastFt;
+		if(fastFt.items && fastFt.items.map) {
+			fastFt.items = fastFt.items.map(it => {
+				return {id: it.id, title: it.title, publishedDate: it.publishedDate}
+			});
+		}
+
+		return Object.assign({}, contentCache[src], {top: top, fastFt: fastFt});
+	}
+}
+
+export default {
+	uk: cachedContent('ukTop'),
+	intl: cachedContent('ukTop')
+}

--- a/server/routes/fastft.js
+++ b/server/routes/fastft.js
@@ -1,0 +1,3 @@
+'use strict';
+
+import {pollContent} from '../services/content-api';

--- a/server/routes/fastft.js
+++ b/server/routes/fastft.js
@@ -1,3 +1,10 @@
 'use strict';
 
-import {pollContent} from '../services/content-api';
+import content from '../lib/content';
+
+module.exports = function(req, res) {
+	const useElasticSearch = res.locals.flags.elasticSearchItemGet.isSwitchedOn;
+	const contentData = content.uk(useElasticSearch);
+
+	res.json(contentData.fastFt);
+};

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -1,5 +1,6 @@
 'use strict';
 import {pollContent} from '../services/content-api';
+import Feed from '../../components/fastft/feed';
 
 const pollConfig = {
 	ukTop: {
@@ -73,6 +74,7 @@ module.exports = function(req, res) {
 
 	res.render('uk', {
 		layout: 'wrapper',
+		Feed: Feed,
 		articles: source.ukTop,
 		fastFt: fastFt
 	});

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -1,81 +1,16 @@
 'use strict';
-import {pollContent} from '../services/content-api';
+
+import content from '../lib/content'
 import Feed from '../../components/fastft/feed';
 
-const pollConfig = {
-	ukTop: {
-		type: 'page',
-		uuid: '520ddb76-e43d-11e4-9e89-00144feab7de', // list id
-		useElasticSearch: true,
-		interval: 60 * 1000
-	},
-	intlTop: {
-		type: 'page',
-		uuid: 'b0d8e4fe-10ff-11e5-8413-00144feabdc0', // list id
-		useElasticSearch: true,
-		interval: 60 * 1000
-	},
-	fastFt: {
-		type: 'concept',
-		uuid: '5c7592a8-1f0c-11e4-b0cb-b2227cce2b54', // concept id
-		useElasticSearch: true,
-		interval: 30 * 1000
-	}
-};
-
-// Content cache for polling
-var content = {
-	elastic: {
-		ukTop: [],
-		intTop: [],
-		fastFt: []
-	},
-	capi1: {
-		ukTop: [],
-		intTop: [],
-		fastFt: []
-	}
-};
-
-// Poll both APIs so that we can feature flag between them
-
-// Poll both APIs so that we can feature flag between them
-
-Object.keys(pollConfig)
-.forEach(it => {
-	if(pollConfig[it].useElasticSearch) {
-		pollContent(
-			pollConfig[it],
-			true,
-			page => content.elastic[it] = page
-		);
-	}
-
-	pollContent(
-		pollConfig[it],
-		false,
-		page => content.capi1[it] = page
-	);
-});
-
 module.exports = function(req, res) {
-	var source = (res.locals.flags.elasticSearchItemGet.isSwitchedOn ? content.elastic : content.capi1);
-	if(source.ukTop.items && source.ukTop.items.slice) {
-		source.ukTop.items = source.ukTop.items.slice(0, 10);
-	}
-
-	// strip fastFt down to bare minimum
-	const fastFt = source.fastFt;
-	if(fastFt.items && fastFt.items.map) {
-		fastFt.items = fastFt.items.map(it => {
-			return {id: it.id, title: it.title, publishedDate: it.publishedDate}
-		});
-	}
+	const useElasticSearch = res.locals.flags.elasticSearchItemGet.isSwitchedOn;
+	const contentData = content.uk(useElasticSearch);
 
 	res.render('uk', {
 		layout: 'wrapper',
 		Feed: Feed,
-		articles: source.ukTop,
-		fastFt: fastFt
+		articles: contentData.top,
+		fastFt: contentData.fastFt
 	});
 };

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import content from '../lib/content'
+import content from '../lib/content';
 import Feed from '../../components/fastft/feed';
 
 module.exports = function(req, res) {

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -63,9 +63,17 @@ module.exports = function(req, res) {
 		source.ukTop.items = source.ukTop.items.slice(0, 10);
 	}
 
+	// strip fastFt down to bare minimum
+	const fastFt = source.fastFt;
+	if(fastFt.items && fastFt.items.map) {
+		fastFt.items = fastFt.items.map(it => {
+			return {id: it.id, title: it.title, publishedDate: it.publishedDate}
+		});
+	}
+
 	res.render('uk', {
 		layout: 'wrapper',
 		articles: source.ukTop,
-		fastFt: source.fastFt
+		fastFt: fastFt
 	});
 };

--- a/views/uk.html
+++ b/views/uk.html
@@ -74,8 +74,7 @@
 			</div>
 		</section>
 		<aside class="sidebar" data-nh-grid-colspan="S4 M3">
-			<section id="fastft" data-fastft-articles="{{json fastFt.items}}">
-			</section>
+			<section id="fastft" data-fastft-articles="{{json fastFt.items}}">{{{ reactRenderToString Feed fastFt }}}</section>
 		</aside>
 	</div>
 </div>

--- a/views/uk.html
+++ b/views/uk.html
@@ -74,20 +74,7 @@
 			</div>
 		</section>
 		<aside class="sidebar" data-nh-grid-colspan="S4 M3">
-			<section>
-				<h1 class='pod-heading'>Fast FT</h1>
-				{{#each fastFt.items}}
-					<article>
-						<h2>{{title}}</h2>
-						<p>{{{summary}}}</p>
-						<time
-							data-o-component="o-date"
-							class="o-date"
-							datetime="{{#dateformat}}{{publishedDate}}{{/dateformat}}">
-								{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}
-						</time>
-					</article>
-				{{/each}}
+			<section id="fastft" data-fastft-articles="{{json fastFt.items}}">
 			</section>
 		</aside>
 	</div>


### PR DESCRIPTION
Renders fastFT with React server-side and client-side. Also adds a json endpoint for fastFT the client can poll and update the feed. Eventually, we'll switch from polling to listening on the fastFT pusher channel.

## Todo

- [x] Render client-side
- [x] Render server-side
- [x] fastFT JSON endpoint
- [x] Poll and re-draw
- [x] sort out `o-date` integration
- [x] style items and hover state