### PR TITLE
Switch back to o-grid

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,8 @@
     "next-sass-setup": "^6.2.6",
     "sass-mq": "^3.1.2",
     "o-date": "^1.1.1",
-    "next-myft-ui": "^3.0.0"
+    "next-myft-ui": "^3.0.0",
+    "o-grid": "git://github.com/financial-times/o-grid.git#flexible-gutters"
   },
   "resolutions": {
     "next-myft-ui": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -6,12 +6,13 @@
     "sass-mq": "^3.1.2",
     "o-date": "^1.1.1",
     "next-myft-ui": "^3.0.0",
-    "o-grid": "git://github.com/financial-times/o-grid.git#flexible-gutters"
+    "o-grid": "4.0.0-beta.1"
   },
   "resolutions": {
     "next-myft-ui": "^3.0.0",
     "o-buttons": "v3",
     "o-fonts": "^2.0.0",
-    "o-ft-icons": "^2.3.4"
+    "o-ft-icons": "^2.3.4",
+    "o-grid": "4.0.0-beta.1"
   }
 }

--- a/client/_flexipod-layouts.scss
+++ b/client/_flexipod-layouts.scss
@@ -32,9 +32,9 @@ $layout-lead-today: (
 
 $layout-opinion: (
 	default: (
-		((12, 'wide'), (12, 'small')),
+		((12, 'tall'), (12, 'small')),
 		(12, 'small'),
-		((12, 'small'), (12, 'wide'))
+		((12, 'small'), (12, 'tall'))
 		),
 	XS: (
 		((12, 'wide'), (12, 'small')),
@@ -50,7 +50,7 @@ $layout-opinion: (
 
 $layout-topic: (
 	default: append((), (
-		((12, 'wide'), (12, 'small'))
+		((12, 'tall'), (12, 'small'))
 	)),
 	S: append((), (
 		((2/3, 'wide'), (1/3, 'small'))

--- a/client/_flexipod-layouts.scss
+++ b/client/_flexipod-layouts.scss
@@ -5,20 +5,25 @@
 $layout-lead-today: (
 	default: (
 		(12, 'large'),
-		(12, 'wide'),
+		(12, 'tall'),
 		(12, 'wideImageless'),
 		),
 	XS: (
 		(12, 'large'),
-		(1/3, 'tall'),
-		(1/3, 'small'),
+		(12, 'wide'),
+		(12, 'wideImageless')
 		),
 	S: (
-		(9, 'large'),
-		(9, 'wide'),
-		(9, 'small'),
-	),
+		(12, 'large'),
+		(12, 'wide'),
+		(1/3, 'small')
+		),
 	M: (
+		(12, 'large'),
+		(1/3, 'tall'),
+		(1/3, 'small')
+	),
+	L: (
 		(9, 'large'),
 		(1/3, 'tall'),
 		(1/3, 'small'),
@@ -31,15 +36,15 @@ $layout-opinion: (
 		(12, 'small'),
 		((12, 'small'), (12, 'wide'))
 		),
-	M: (
-		((2/3, 'wide'), (1/3, 'small')),
-		(1/3, 'medium'),
-		((1/3, 'small'), (2/3, 'wide')),
-	),
 	XS: (
 		((12, 'wide'), (12, 'small')),
 		(1/3, 'medium'),
 		((12, 'small'), (12, 'wide'))
+	),
+	M: (
+		((2/3, 'wide'), (1/3, 'small')),
+		(1/3, 'medium'),
+		((1/3, 'small'), (2/3, 'wide')),
 	)
 );
 
@@ -47,15 +52,9 @@ $layout-topic: (
 	default: append((), (
 		((12, 'wide'), (12, 'small'))
 	)),
-	M: append((), (
-		((2/3, 'wide'), (1/3, 'small'))
-	)),
 	S: append((), (
-		((9, 'wide'), (9, 'small'))
-	)),
-	XS: append((), (
 		((2/3, 'wide'), (1/3, 'small'))
-	)),
+	))
 );
 
 $layout-editors: (

--- a/client/_type.scss
+++ b/client/_type.scss
@@ -14,7 +14,7 @@
 	overflow: hidden;
 	border: solid oColorsGetPaletteColor('warm-3');
 	border-width: 0 0 1px;
-	margin-bottom: 20px;
+	margin-bottom: 10px;
 	h1 {
 		@include podHeading;
 		float: left;

--- a/client/components/carousel-card/main.scss
+++ b/client/components/carousel-card/main.scss
@@ -41,12 +41,13 @@
 .carousel-card__image {
 	@include oGridColumn(4);
 	margin-bottom: 10px;
-	padding-right: 3px;
 	float: left;
 
 
 	@include oGridRespondTo(XS) {
 		width: 100%;
+		padding: 0;
+		margin: 0 0 10px 0;
 		display: inline;
 	}
 

--- a/client/components/carousel-card/main.scss
+++ b/client/components/carousel-card/main.scss
@@ -4,8 +4,8 @@
 	width: 100%;
 	text-align: left;
 
-	@include nhGridColumn((default: 12, XS: 6, S: 4, M: 2));
-	@include nhGridRespondTo(S) { text-align: center; }
+	@include oGridColumn((default: 12, XS: 6, S: 4, L: 2));
+	@include oGridRespondTo(S) { text-align: center; }
 
 	margin-top: 0px;
 	margin-bottom: 20px;
@@ -35,17 +35,17 @@
 }
 
 .carousel-card__content {
-	@include nhGridColumn((default: 8, S: 12));
+	@include oGridColumn((default: 8, XS: 12));
 }
 
 .carousel-card__image {
-	@include nhGridColumn(4);
+	@include oGridColumn(4);
 	margin-bottom: 10px;
 	padding-right: 3px;
 	float: left;
 
 
-	@include nhGridRespondTo(S) {
+	@include oGridRespondTo(XS) {
 		width: 100%;
 		display: inline;
 	}
@@ -53,11 +53,11 @@
 }
 
 .flexipod--editors .carousel-card {
-	@include nhGridRespondTo($from: XS, $until: S) {
+	@include oGridRespondTo($from: XS, $until: S) {
 		&:nth-child(2n+1) { clear: both; }
 	}
 
-	@include nhGridRespondTo($from: S, $until: M) {
+	@include oGridRespondTo($from: S, $until: L) {
 		&:nth-child(3n+1) { clear: both; }
 	}
 }

--- a/client/components/flexipod/main.scss
+++ b/client/components/flexipod/main.scss
@@ -28,6 +28,8 @@
 }
 
 @mixin nhFlexipodCard($int, $card-spec, $total-cols: $o-grid-columns) {
+	$subgrid-ratio: $total-cols / $o-grid-columns;
+
 	@if type-of(nth($card-spec, 1)) == number {
 		$width: nth($card-spec, 1);
 		$type: nth($card-spec, 2);
@@ -35,16 +37,34 @@
 		.article-group:nth-child(#{$int}) {
 			@if $width < 1 {
 				display: flex;
+				align-items: stretch;
 			} @else {
 				display: block;
+			}
+
+			// compensate for Gecko's to-the-letter interpretation of the standard
+			// when computing fractional vertical paddings in a flexbox
+			@-moz-document url-prefix() {
+				padding: percentage($o-grid-gutter / 2) 0;
 			}
 
 			.article {
 				width: oGridColspan($width, $total-cols);
 				@if $width < 1 {
 					display: flex;
-				} @else {
-					display: block;
+
+					// and again
+					@-moz-document url-prefix() {
+						padding-top: 0;
+						padding-bottom: 0;
+					}
+				}
+
+				&.no-ff-padding {
+					@-moz-document url-prefix() {
+						padding-top: 0;
+						padding-bottom: 0;
+					}
 				}
 
 				.story-card {
@@ -60,13 +80,25 @@
 				$width: nth($nested-card, 1);
 				$type: nth($nested-card, 2);
 
+				// and again
+				@-moz-document url-prefix() {
+					padding: percentage($o-grid-gutter / 2) 0;
+				}
+
 				.article:nth-child(#{$card-int}) {
 					width: oGridColspan($width, $total-cols);
 					@if $width < 1 {
 						display: flex;
+
+						// and one last time, sigh.
+						@-moz-document url-prefix() {
+							padding-top: 0;
+							padding-bottom: 0;
+						}
 					} @else {
 						display: block;
 					}
+
 
 					.story-card {
 						@include nhStoryCard($type);

--- a/client/components/flexipod/main.scss
+++ b/client/components/flexipod/main.scss
@@ -6,6 +6,8 @@
 @mixin nhFlexipod($layout-spec, $total-cols: $o-grid-columns) {
 	.article-group {
 		@include oGridRow($total-cols);
+		@include oGridRowReset($total-cols);
+
 		clear: both;
 
 		.article {

--- a/client/components/flexipod/main.scss
+++ b/client/components/flexipod/main.scss
@@ -1,23 +1,22 @@
 @import "variables";
 @import "next-type/main";
 
-@import "../grid/main";
+@import "o-grid/main";
 
-@mixin nhFlexipod($layout-spec, $total-cols: $nh-grid-columns) {
+@mixin nhFlexipod($layout-spec, $total-cols: $o-grid-columns) {
 	.article-group {
-		@include nhGridRow($total-cols);
+		@include oGridRow($total-cols);
 		clear: both;
 
-		.story-card {
-			@include nhGridColumn(null, $total-cols);
+		.article {
+			@include oGridColumn(null, $total-cols);
 		}
 	}
 
-	@include nhGridContainer;
 	@include nhFlexipodLayout($layout-spec, $total-cols);
 }
 
-@mixin nhFlexipodLayout($layout-spec, $total-cols: $nh-grid-columns) {
+@mixin nhFlexipodLayout($layout-spec, $total-cols: $o-grid-columns) {
 	@if type-of($layout-spec) == list {
 		@for $int from 1 through length($layout-spec) {
 			$card-spec: nth($layout-spec, $int);
@@ -26,7 +25,7 @@
 	}
 }
 
-@mixin nhFlexipodCard($int, $card-spec, $total-cols: $nh-grid-columns) {
+@mixin nhFlexipodCard($int, $card-spec, $total-cols: $o-grid-columns) {
 	@if type-of(nth($card-spec, 1)) == number {
 		$width: nth($card-spec, 1);
 		$type: nth($card-spec, 2);
@@ -34,16 +33,21 @@
 		.article-group:nth-child(#{$int}) {
 			@if $width < 1 {
 				display: flex;
-				@-moz-document url-prefix() {
-					margin-bottom: 0;
-				}
 			} @else {
 				display: block;
 			}
 
-			.story-card {
-				@include nhStoryCard($type);
-				width: nhGridColspan($width, $total-cols);
+			.article {
+				width: oGridColspan($width, $total-cols);
+				@if $width < 1 {
+					display: flex;
+				} @else {
+					display: block;
+				}
+
+				.story-card {
+					@include nhStoryCard($type);
+				}
 			}
 		}
 
@@ -54,22 +58,25 @@
 				$width: nth($nested-card, 1);
 				$type: nth($nested-card, 2);
 
-				.story-card:nth-child(#{$card-int}) {
-					@include nhStoryCard($type);
-					width: nhGridColspan($width, $total-cols);
+				.article:nth-child(#{$card-int}) {
+					width: oGridColspan($width, $total-cols);
+					@if $width < 1 {
+						display: flex;
+					} @else {
+						display: block;
+					}
+
+					.story-card {
+						@include nhStoryCard($type);
+					}
 				}
 
 				@if $width < 1 {
 					display: flex;
-					// HACK target Firefox
-					@-moz-document url-prefix() {
-						margin-bottom: 0;
-					}
 				} @else {
 					display: block;
 				}
 			}
-
 		}
 	}
 }

--- a/client/components/grid/main.scss
+++ b/client/components/grid/main.scss
@@ -30,9 +30,6 @@
 }
 
 @mixin nhGridRow($total-cols: $nh-grid-columns) {
-	// negative margin to swallow the outer column's margins
-	$subgrid-ratio: $nh-grid-columns / $total-cols;
-
 	@include nhRowMargins($total-cols);
 }
 

--- a/client/components/header-tabs/main.scss
+++ b/client/components/header-tabs/main.scss
@@ -37,12 +37,12 @@
 		}
 
 		a {
-			@include nhGridColumn(1/2);
+			@include oGridColumn(1/2);
 
 			text-align: center;
 			cursor: pointer;
 			overflow-y: visible;
-			margin: 0;
+			padding: 0;
 
 			span {
 				padding: 0.5em;

--- a/client/components/story-card/main.scss
+++ b/client/components/story-card/main.scss
@@ -158,7 +158,7 @@
 
 @mixin nhWideCard() {
 	.story-card__image {
-		@include oGridColumn(4, 9);
+		@include oGridColumn(3, 9);
 		height: 100%;
 		display: block;
 		float: left;

--- a/client/components/story-card/main.scss
+++ b/client/components/story-card/main.scss
@@ -13,14 +13,13 @@
 
 .story-card {
 	background-color: oColorsGetPaletteColor('warm-base');
-	float: left;
-	display: flex;
+	width: 100%;
 	overflow: hidden;
 	padding-bottom: $story-card--footer-height;
 	position: relative;
 	font-size: 18px;
 
-	@include nhGridRespondTo(M) {
+	@include oGridRespondTo(M) {
 		font-size: 20px;
 	}
 
@@ -35,7 +34,7 @@
 	padding: 7px;
 }
 
-.story-card--link { align-items: stretch; }
+// .story-card__link { align-items: stretch; }
 
 .story-card__heading {
 	display: inline-block;
@@ -52,12 +51,12 @@
 }
 
 .story-card__related-link {
-	@include nhGridColumn((default: 12, XS:4, S:12, M:4));
-	@include nhGridRespondTo($from: XS, $until: S) { border-bottom: none; }
-	@include nhGridRespondTo($from: M) { border-bottom: none; }
+	@include oGridColumn((default: 12, M: 4));
+	@include oGridRespondTo($from: M) { border-bottom: none; }
 
 	border-bottom: 1px dotted oColorsGetPaletteColor('warm-3');
 	margin-bottom: 4px;
+	padding: 0;
 	padding-bottom: 4px;
 }
 
@@ -102,30 +101,32 @@
 }
 
 @mixin nhLargeCard() {
-	@include nhGridRespondTo($from: M) {
+	@include oGridRespondTo($from: L) {
 		.story-card__summary {
 			display: initial;
 		}
 	}
 
 	.story-card__image {
-		@include nhGridColumn(6, 9);
-		margin: 0;
+		@include oGridColumn(6, 9);
+		padding-top: 0;
+		padding-bottom: 0;
+		padding-left: 0;
 		height: auto;
 		display: block;
 	}
 
-	.story-card__content { @include nhGridColumn(3, 9); }
+	.story-card__content { @include oGridColumn(3, 9); }
 
 	.story-card__image,
 	.story-card__content {
-		@include nhGridRespondTo($until: XS) {
+		@include oGridRespondTo($until: M) {
 			width: 100%;
 		}
 
-		@include nhGridRespondTo($from:S, $until: M) {
-			width: 100%;
-		}
+		// @include oGridRespondTo($from:S, $until: L) {
+		// 	width: 100%;
+		// }
 	}
 }
 
@@ -143,6 +144,7 @@
 }
 
 @mixin nhTallCard {
+	display: block;
 	padding-bottom: 42px;
 
 	.story-card__image {
@@ -152,19 +154,15 @@
 	}
 
 	.story-card__summary { display: initial; }
-
-	.story-card__summary {
-	}
-
 }
 
 @mixin nhWideCard() {
 	.story-card__image {
-		@include nhGridColumn(4, 9);
+		@include oGridColumn(4, 9);
 		height: 100%;
 		display: block;
 		float: left;
-		margin: 0;
+		padding: 0;
 	}
 
 	.story-card__content { margin: 0; }

--- a/client/main.scss
+++ b/client/main.scss
@@ -1,3 +1,20 @@
+$o-grid-column: 100 / 1440;
+$o-grid-gutter: 20 / 1440;
+
+$o-grid-layouts: (
+	XS: 330px,
+	S: 480px,
+	M: 720px,
+	L: 960px,
+	XL: 1200px
+//	XXL: 1440px
+);
+
+$o-grid-min-width: 280px;
+$o-grid-start-snappy-mode-at: XL;
+
+// Shut up next-sass-setup
+$_next-ui-setup-first-pass: false;
 @import "next-sass-setup/main";
 
 @import "colors";
@@ -23,9 +40,11 @@
 
 $container-widths: (
 	XS: 100%,
-	S: 730px,
-	M: 970px,
-	L: 1210px
+	S: 100%,
+	M: 100%,
+	L: 100%,
+	XL: 100%
+//	XXL: 1440px
 );
 
 html {
@@ -65,7 +84,7 @@ body {
 	padding: 0;
 	margin: 0;
 
-	@include nhGridGenerate();
+	@include oGridGenerate();
 	@include nhHeaderTabs();
 
 	// Top tabs (News, fastFT)
@@ -74,7 +93,7 @@ body {
 		display: none;
 	}
 
-	@include nhGridRespondTo($until: S) {
+	@include oGridRespondTo($until: L) {
 		@include nhHeaderTabsActive();
 
 		.nh-header-tabs__tablist {
@@ -113,11 +132,11 @@ body {
 }
 
 .fixed-width-container {
-	padding-left: percentage($nh-grid-gutter / 2);
-	padding-right: percentage($nh-grid-gutter / 2);
+	padding-left: percentage($o-grid-gutter / 2);
+	padding-right: percentage($o-grid-gutter / 2);
 
 	@each $layout in $container-widths {
-		@include nhGridRespondTo(nth($layout, 1)) {
+		@include oGridRespondTo(nth($layout, 1)) {
 			$width: nth($layout, 2);
 
 			@if $width != 100% {
@@ -126,38 +145,30 @@ body {
 		}
 	}
 
-	@include nhGridContainer;
 	margin: 0 auto;
 }
 
-.fastft--header {
-	@include nhFastFtTitle;
-	@include nhRowMargins;
-
-	background-color: oColorsGetPaletteColor(warm-base);
-	padding: 5px 0.25em 0 0.2em;
-	border-bottom: 1px solid oColorsGetPaletteColor(fastft-brand);
-
-	@include nhGridRespondTo($from: S) { display: none };
-}
-
 .main-content {
-	@include nhGridColumn($span: (default: 12, M: 9, S: 8));
+	@include oGridColumn($span: (default: 12, L: 9));
 
 	.flexipod--lead-today {
 		// TODO think about sinking the breakpoints into nhFlexipod
 		@include nhFlexipod(map-get($layout-lead-today, default));
 
-		@include nhGridRespondTo(XS) {
+		@include oGridRespondTo(XS) {
 			@include nhFlexipod(map-get($layout-lead-today, XS));
 		}
 
-		@include nhGridRespondTo(S) {
-			@include nhFlexipod(map-get($layout-lead-today, S), 9);
+		@include oGridRespondTo(S) {
+			@include nhFlexipod(map-get($layout-lead-today, S));
 		}
 
-		@include nhGridRespondTo(M) {
-			@include nhFlexipod(map-get($layout-lead-today, M), 9);
+		@include oGridRespondTo(M) {
+			@include nhFlexipod(map-get($layout-lead-today, M));
+		}
+
+		@include oGridRespondTo(L) {
+			@include nhFlexipod(map-get($layout-lead-today, L), 9);
 		}
 	}
 
@@ -165,15 +176,11 @@ body {
 		// TODO think about sinking the breakpoints into nhFlexipod
 		@include nhFlexipod(map-get($layout-opinion, default));
 
-		@include nhGridRespondTo(XS) {
-			@include nhFlexipod(map-get($layout-opinion, XS));
+		@include oGridRespondTo(S) {
+			@include nhFlexipod(map-get($layout-opinion, S));
 		}
 
-		@include nhGridRespondTo(S) {
-			@include nhFlexipod(map-get($layout-opinion, S), 9);
-		}
-
-		@include nhGridRespondTo(M) {
+		@include oGridRespondTo(M) {
 			@include nhFlexipod(map-get($layout-opinion, M), 9);
 		}
 	}
@@ -182,35 +189,31 @@ body {
 		// TODO think about sinking the breakpoints into nhFlexipod
 		@include nhFlexipod(map-get($layout-topic, default));
 
-		@include nhGridRespondTo(XS) {
-			@include nhFlexipod(map-get($layout-topic, XS));
+		@include oGridRespondTo(S) {
+			@include nhFlexipod(map-get($layout-topic, S));
 		}
 
-		@include nhGridRespondTo(S) {
+		@include oGridRespondTo(M) {
 			@include nhFlexipod(map-get($layout-topic, S), 9);
-		}
-
-		@include nhGridRespondTo(M) {
-			@include nhFlexipod(map-get($layout-topic, M), 9);
 		}
 	}
 
 	.flexipod--editors {
 		.article-group {
-			@include nhGridRow(12);
+			@include oGridRow(12);
 		}
 	}
 }
 
 .next-header {
-	@include nhGridRespondTo($from: S) { margin-bottom: 20px; }
+	@include oGridRespondTo($from: L) { margin-bottom: 20px; }
 }
 
 .sidebar {
 	&.sidebar--fastft {
 		display: none;
 
-		@include nhGridRespondTo($from: S) {
+		@include oGridRespondTo($from: L) {
 			display: block;
 		}
 	}

--- a/client/main.scss
+++ b/client/main.scss
@@ -132,9 +132,6 @@ body {
 }
 
 .fixed-width-container {
-	padding-left: percentage($o-grid-gutter / 2);
-	padding-right: percentage($o-grid-gutter / 2);
-
 	@each $layout in $container-widths {
 		@include oGridRespondTo(nth($layout, 1)) {
 			$width: nth($layout, 2);
@@ -176,6 +173,10 @@ body {
 		// TODO think about sinking the breakpoints into nhFlexipod
 		@include nhFlexipod(map-get($layout-opinion, default));
 
+		@include oGridRespondTo(XS) {
+			@include nhFlexipod(map-get($layout-opinion, XS));
+		}
+
 		@include oGridRespondTo(S) {
 			@include nhFlexipod(map-get($layout-opinion, S));
 		}
@@ -200,7 +201,8 @@ body {
 
 	.flexipod--editors {
 		.article-group {
-			@include oGridRow(12);
+			@include oGridRow;
+			@include oGridRowReset;
 		}
 	}
 }
@@ -239,7 +241,7 @@ body {
 	position: relative;
 	background-color: oColorsGetPaletteColor('warm-carousel');
 	padding: 10px 0;
-	margin-bottom: 20px;
+	margin: 20px 0;
 	&::before, &::after {
 		@include dots;
 		position: absolute;

--- a/views/partials/lead-today.html
+++ b/views/partials/lead-today.html
@@ -1,17 +1,23 @@
 <section class="flexipod flexipod--lead-today" id="site-content" data-trackable="lead-today" role="region" tabindex="0" aria-labelledby="lead-pod-title">
 	<div class="article-group" role="presentation">
 		{{#slice leads limit=1}}
-			{{> story-card related=true }}
+			<div class="article">
+				{{> story-card related=true }}
+			</div>
 		{{/slice}}
 	</div>
 	<div class="article-group" role="presentation">
 		{{#slice items limit=3}}
-			{{> story-card }}
+			<div class="article">
+				{{> story-card }}
+			</div>
 		{{/slice}}
 	</div>
 	<div class="article-group" role="presentation">
 		{{#slice items limit=3 offset=3}}
-			{{> story-card }}
+			<div class="article">
+				{{> story-card }}
+			</div>
 		{{/slice}}
 	</div>
 </section>

--- a/views/partials/lead-today.html
+++ b/views/partials/lead-today.html
@@ -1,7 +1,7 @@
 <section class="flexipod flexipod--lead-today" id="site-content" data-trackable="lead-today" role="region" tabindex="0" aria-labelledby="lead-pod-title">
 	<div class="article-group" role="presentation">
 		{{#slice leads limit=1}}
-			<div class="article">
+			<div class="article no-ff-padding">
 				{{> story-card related=true showSummary=true }}
 			</div>
 		{{/slice}}

--- a/views/partials/lead-today.html
+++ b/views/partials/lead-today.html
@@ -2,7 +2,7 @@
 	<div class="article-group" role="presentation">
 		{{#slice leads limit=1}}
 			<div class="article">
-				{{> story-card related=true }}
+				{{> story-card related=true showSummary=true }}
 			</div>
 		{{/slice}}
 	</div>

--- a/views/partials/opinion.html
+++ b/views/partials/opinion.html
@@ -9,17 +9,23 @@
 	<div role="presentation">
 		<div class="article-group">
 			{{#slice items limit=2}}
-				{{> story-card }}
+				<div class="article">
+					{{> story-card }}
+				</div>
 			{{/slice}}
 		</div>
 		<div class="article-group">
 			{{#slice items limit=3 offset=2}}
-				{{> story-card }}
+				<div class="article">
+					{{> story-card }}
+				</div>
 			{{/slice}}
 		</div>
 		<div class="article-group">
 			{{#slice items limit=2 offset=5}}
-				{{> story-card }}
+				<div class="article">
+					{{> story-card }}
+				</div>
 			{{/slice}}
 		</div>
 	</div>

--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -14,7 +14,9 @@
 		</a>
 			<a href="/{{id}}" class="story-card__link" data-trackable="main-link">
 				<h1 id="{{id}}-title" class="story-card__title" data-trackable="title">{{title}}</h1>
-				<h2 class="story-card__summary" data-trackable="summary">{{{summary}}}</h2>
+				{{#if showSummary}}
+					<h2 class="story-card__summary" data-trackable="summary">{{{summary}}}</h2>
+				{{/if}}
 			</a>
 	</div>
 	{{#if relatedContent}}

--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -1,6 +1,6 @@
 <article class='story-card article--{{genre}}' data-trackable="story" tabindex="0" aria-labelledby="{{id}}-title" role="article">
 	{{#if primaryImage}}
-		<a href="/{{id}}" class="story-card--link" data-trackable="image" role="presentation" aria-hidden="true">
+		<a href="/{{id}}" class="story-card__link" data-trackable="image" role="presentation" aria-hidden="true">
 			{{#with primaryImage}}
 				<img class='story-card__image'
 				src="{{src}}" alt=""
@@ -9,10 +9,10 @@
 		</a>
 	{{/if}}
 	<div class="story-card__content">
-		<a href="{{{primaryTag.url}}}" data-trackable="primary-tag" class="story-card--link">
+		<a href="{{{primaryTag.url}}}" data-trackable="primary-tag" class="story-card__link">
 			<div class="story-card__taxon" aria-label="Topic: {{primaryTag.name}}">{{primaryTag.name}}</div>
 		</a>
-			<a href="/{{id}}" class="story-card--link" data-trackable="main-link">
+			<a href="/{{id}}" class="story-card__link" data-trackable="main-link">
 				<h1 id="{{id}}-title" class="story-card__title" data-trackable="title">{{title}}</h1>
 				<h2 class="story-card__summary" data-trackable="summary">{{{summary}}}</h2>
 			</a>
@@ -21,7 +21,7 @@
 		<div class="story-card__related" data-trackable="related-links" tabindex="0" role="group" aria-label="Related links">
 			{{#slice relatedContent limit=3}}
 				<article class="story-card__related-link" aria-labelledby="{{id}}-title" tabindex="0" role="article">
-					<a href="{{{primaryTag.url}}}" data-trackable="primary-tag" class="story-card--link">
+					<a href="{{{primaryTag.url}}}" data-trackable="primary-tag" class="story-card__link">
 						<span class="story-card__taxon" aria-label="Topic: {{primaryTag.name}}">{{primaryTag.name}}</span></a><span aria-hidden="true">|</span>
 					<a href="/{{id}}" data-trackable="title" role="heading"><span id="{{id}}-title">{{title}}</span></a>
 				</article>

--- a/views/partials/topic.html
+++ b/views/partials/topic.html
@@ -9,7 +9,9 @@
 	<div role="presentation">
 		<div class="article-group">
 			{{#slice items limit=2}}
-				{{> story-card }}
+				<div class="article">
+					{{> story-card }}
+				</div>
 			{{/slice}}
 		</div>
 	</div>

--- a/views/uk.html
+++ b/views/uk.html
@@ -6,20 +6,20 @@
 <a id="news-tab" class="nh-header-tabs__marker" >News</a>
 <a id="fastft-tab" class="nh-header-tabs__marker" >fastFT</a>
 <div class="fixed-width-container">
-	<div class="nh-grid-row">
+	<div class="o-grid-row">
 		<div class="main-content nh-header-tabs__panel">
 			<h1 class="u-visually-hidden" id="lead-pod-title">Top stories</h1>
 			{{> lead-today leads=content.top.leads items=content.top.items }}
 		</div>
-		<aside class="sidebar sidebar--fastft nh-header-tabs__panel" data-trackable="fastft" data-nh-grid-colspan="12 S4 M4" role="presentation">
+		<aside class="sidebar sidebar--fastft nh-header-tabs__panel" data-trackable="fastft" data-o-grid-colspan="12 L3" role="presentation">
 			<section id="fastft" data-fastft-articles="{{json content.fastFT.items}}">{{{ reactRenderToString FastFtFeed items=content.fastFT.items }}}</section>
 		</aside>
 	</div>
 </div>
-<div class="nh-grid-container bordered-row nh-header-tabs__panel">
+<div class="o-grid-container bordered-row nh-header-tabs__panel">
 	<div class="fixed-width-container">
-		<div class="nh-grid-row">
-			<div class="main-content" data-nh-grid-colspan="12">
+		<div class="o-grid-row">
+			<div class="main-content" data-o-grid-colspan="12">
 				<div class="flexipod flexipod--editors" data-trackable="editors-picks" id="editors-picks">
 					<h1 class='carousel-heading' id="editors-picks-title" aria-hidden="true">Editor's Picks</h1>
 					{{> editors items=content.editorsPicks.items id="editors-picks"}}
@@ -29,7 +29,7 @@
 	</div>
 </div>
 <div class="fixed-width-container nh-header-tabs__panel">
-	<div class="nh-grid-row">
+	<div class="o-grid-row">
 		<div class="main-content">
 			{{> opinion items=content.opinion.items url=content.opinion.url title="Opinion" id="opinion" }}
 			<div class="bordered-spacer"></div>
@@ -39,7 +39,7 @@
 			<div class="bordered-spacer"></div>
 			{{> topic items=content.technology.items url=content.technology.url title="Technology" id="technology" }}
 		</div>
-		<aside class="sidebar sidebar--feed" role="presentation" data-nh-grid-colspan="12 S4 M4">
+		<aside class="sidebar sidebar--feed" role="presentation" data-o-grid-colspan="12 L3">
 			<section class="feed feed--popular" data-trackable="popular">
 				<div>
 					<div class="pod-heading pod-heading--feed">


### PR DESCRIPTION
This switches our layout to the updated o-grid (Financial-Times/o-grid#93). As part of the update we reshuffled the stacking and layouts a little to make it more sensible.

# To Do

- [x] make everything look good
- [x] switch to fully fluid, now it's o-grid all the way down
- [x] re-fix Firefox issue
- [x] switch to ~~tagged version of o-grid once the PR is merged~~ o-grid 4.0.0-beta.1
- [x] make sure all's good on most browsers & devices