### PR TITLE
Keep preferring brands to topics for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "forever": "^0.14.2",
     "ft-api-client": "^4.0.1",
     "ft-next-article-genre": "^1.2.0",
-    "ft-next-article-primary-tag": "^1.0.1",
+    "ft-next-article-primary-tag": "1.0.1",
     "ft-next-express": "^12.2.0",
     "ft-poller": "0.0.4",
     "graphql": "^0.1.3",


### PR DESCRIPTION
This is a temporary treatment before we can surface brands and topics separately, so that we can show columnists name in Opinion section.