### PR TITLE
FastFt feed notifications

### DIFF
--- a/server/config/queries.js
+++ b/server/config/queries.js
@@ -128,4 +128,4 @@ query FastFT {
 export default {
 	frontPage,
 	fastFT
-}
+};

--- a/server/graphql/backend.js
+++ b/server/graphql/backend.js
@@ -9,7 +9,7 @@ class Backend {
 		this.elasticSearch = elasticSearch;
 		this.type = (elasticSearch ? 'elasticsearch' : 'capi');
 
- 		// in-memory content cache
+		// in-memory content cache
 		this.contentCache = {};
 
 		const sweeper = () => {
@@ -20,10 +20,10 @@ class Backend {
 					delete this.contentCache[key];
 				}
 			}
-		}
+		};
 
 		// keep clearing the cache every minute
-		setInterval(sweeper, 60*1000);
+		setInterval(sweeper, 60 * 1000);
 	}
 
 	// Caching wrapper. Always returns a promise, when cache expires
@@ -31,22 +31,22 @@ class Backend {
 	cached(key, ttl, fetcher) {
 		const cache = this.contentCache;
 
-		const data = (cache[key] && cache[key].data);
-		const expire = (cache[key] && cache[key].expire);
+		const data = (cache[key] && cache[key].data);
+		const expire = (cache[key] && cache[key].expire);
 		const now = (new Date().getTime()) / 1000;
 
 		// we have fresh data
 		if(expire > now && data) { return Promise.resolve(data); }
 
 		// fetch fresh data
-		const eventualData = fetcher()
+		const eventualData = fetcher(data, expire)
 		.then((it) => {
-			let expire = now + ttl;
+			let expiry = now + ttl;
 
 			this.contentCache[key] = {
-				expire: expire,
+				expire: expiry,
 				data: it
-			}
+			};
 
 			return it;
 		});
@@ -79,7 +79,7 @@ class Backend {
 				sectionId: null,
 				items: ids.slice()
 			}));
-		})
+		});
 	}
 
 	search(query, ttl = 50) {
@@ -116,7 +116,7 @@ class Backend {
 			return ApiClient.contentLegacy({
 				uuid: uuids,
 				useElasticSearch: this.elasticSearch
-			})
+			});
 		})
 		.then(items => {
 			if(genres && genres.length) {
@@ -127,7 +127,7 @@ class Backend {
 			items = (limit ? items.slice(0, limit) : items);
 
 			return items;
-		})
+		});
 	}
 
 	contentv2(uuids, {from, limit, genres}) {
@@ -135,7 +135,7 @@ class Backend {
 			return ApiClient.content({
 				uuid: uuids,
 				useElasticSearch: this.elasticSearch
-			})
+			});
 		})
 		.then(items => {
 			if(genres && genres.length) {
@@ -146,12 +146,12 @@ class Backend {
 			items = (limit ? items.slice(0, limit) : items);
 
 			return items;
-		})
+		});
 	}
 }
 
 // expire old content after 10 minutes
-const esBackend = new Backend(true, 10 * 60);
-const capiBackend = new Backend(false, 10 * 60);
+const esBackend = new Backend(true, 10 * 60);
+const capiBackend = new Backend(false, 10 * 60);
 
-export default (elasticSearch) => (elasticSearch ? esBackend : capiBackend)
+export default (elasticSearch) => (elasticSearch ? esBackend : capiBackend);

--- a/server/graphql/fast-ft-feed.js
+++ b/server/graphql/fast-ft-feed.js
@@ -60,7 +60,6 @@ class FastFtFeed {
 	fetch() {	return this.contentCache; }
 }
 
-// expire old content after 10 minutes
 const esBackend = new FastFtFeed(true);
 const capiBackend = new FastFtFeed(false);
 

--- a/server/graphql/fastFtFeed.js
+++ b/server/graphql/fastFtFeed.js
@@ -1,0 +1,69 @@
+import fetch from 'isomorphic-fetch';
+import {fastFt as config} from './config/sources.js';
+import ApiClient from 'next-ft-api-client';
+
+// Polls for changes on the notification api to determine whether a fetch should
+// be made for new content. Hopefully this is a little nicer to the content api
+// polling it directly.
+
+class FastFtFeed {
+	constructor(elasticSearch) {
+		this.elasticSearch = elasticSearch;
+		this.type = (elasticSearch ? 'elasticsearch' : 'capi');
+
+		// in-memory content cache
+		this.contentCache = {};
+		this.since = new Date().toISOString();
+		this.fetchFastFt();
+		this.pollUpdates();
+	}
+
+	fetchFastFt() {
+		const {uuid} = config;
+		return ApiClient.contentAnnotatedBy({
+			uuid: uuid,
+			useElasticSearch: this.elasticSearch
+		})
+		.then(ids => {
+			this.contentCache = {
+				title: "fastFt",
+				conceptId: uuid,
+				sectionId: null,
+				items: ids.slice()
+			};
+			return this.contentCache;
+		}).catch(console.error);
+	}
+
+	pollUpdates() {
+		this.poller = setInterval(() => {
+			this.hasNewUpdates()
+			.then(hasNewUpdates => {
+				console.log('Checking for fastFT updates since %s', this.since);
+				if(hasNewUpdates) {
+					console.log('fastFt updates found. Updating cache...');
+					this.fetchFastFt();
+					this.since = new Date().toISOString();
+				}
+			})
+			.catch(console.error);
+		}, 25 * 1000);
+	}
+	// Requests a list of notifications for FastFT to determine whether there are
+	// any new items.
+	hasNewUpdates() {
+		const url = `http://api.ft.com/content/notifications?since=${this.since}&apiKey=${process.env.FAST_FT_KEY}`;
+		return fetch(url)
+			.then(res => res.json())
+			.then(json => !!json.notifications.length)
+			.catch(console.error);
+	}
+
+	fetch() {	return this.contentCache; }
+}
+
+// expire old content after 10 minutes
+const esBackend = new FastFtFeed(true);
+const capiBackend = new FastFtFeed(false);
+
+export default (elasticSearch) => (elasticSearch ? esBackend : capiBackend);

--- a/server/graphql/fastFtFeed.js
+++ b/server/graphql/fastFtFeed.js
@@ -39,9 +39,7 @@ class FastFtFeed {
 		this.poller = setInterval(() => {
 			this.hasNewUpdates()
 			.then(hasNewUpdates => {
-				console.log('Checking for fastFT updates since %s', this.since);
 				if(hasNewUpdates) {
-					console.log('fastFt updates found. Updating cache...');
 					this.fetchFastFt();
 					this.since = new Date().toISOString();
 				}

--- a/server/graphql/schema.js
+++ b/server/graphql/schema.js
@@ -1,14 +1,13 @@
 import {Promise} from 'es6-promise';
 
 import {
-  graphql,
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLNonNull
 } from 'graphql';
 
-import {Region} from './types/basic'
-import {Collection} from './types/collections'
+import {Region} from './types/basic';
+import {Collection} from './types/collections';
 
 import sources from './config/sources';
 
@@ -57,7 +56,7 @@ const queryType = new GraphQLObjectType({
 						default:
 							throw "Unknown type: " + it.type;
 					}
-				})
+				});
 
 				return Promise.all(promises)
 				.then(ids => ({
@@ -65,13 +64,13 @@ const queryType = new GraphQLObjectType({
 					conceptId: null,
 					sectionId: null,
 					items: ids
-				}))
+				}));
 			}
 		},
 		opinion: {
 			type: Collection,
 			resolve: (root, _, {backend}) => {
-				let {uuid, sectionsId} = sources.opinion
+				let {uuid, sectionsId} = sources.opinion;
 
 				return backend.page(uuid, sectionsId);
 			}
@@ -79,7 +78,7 @@ const queryType = new GraphQLObjectType({
 		lifestyle: {
 			type: Collection,
 			resolve: (root, _, {backend}) => {
-				let {uuid, sectionsId} = sources.lifestyle
+				let {uuid, sectionsId} = sources.lifestyle;
 
 				return backend.page(uuid, sectionsId);
 			}
@@ -87,7 +86,7 @@ const queryType = new GraphQLObjectType({
 		markets: {
 			type: Collection,
 			resolve: (root, _, {backend}) => {
-				let {uuid, sectionsId} = sources.markets
+				let {uuid, sectionsId} = sources.markets;
 
 				return backend.page(uuid, sectionsId);
 			}
@@ -95,7 +94,7 @@ const queryType = new GraphQLObjectType({
 		technology: {
 			type: Collection,
 			resolve: (root, _, {backend}) => {
-				let {uuid, sectionsId} = sources.technology
+				let {uuid, sectionsId} = sources.technology;
 
 				return backend.page(uuid, sectionsId);
 			}

--- a/server/graphql/schema.js
+++ b/server/graphql/schema.js
@@ -28,10 +28,9 @@ const queryType = new GraphQLObjectType({
 		},
 		fastFT: {
 			type: Collection,
-			resolve: (root, _, {backend}) => {
-				let uuid = sources.fastFt.uuid;
-
-				return backend.byConcept(uuid, 'fastFT', 25);
+			resolve: (root, _, {fastFtFeed}) => {
+				const uuid = sources.fastFt.uuid;
+				return fastFtFeed.fetch();
 			}
 		},
 		editorsPicks: {

--- a/server/graphql/schema.js
+++ b/server/graphql/schema.js
@@ -29,7 +29,6 @@ const queryType = new GraphQLObjectType({
 		fastFT: {
 			type: Collection,
 			resolve: (root, _, {fastFtFeed}) => {
-				const uuid = sources.fastFt.uuid;
 				return fastFtFeed.fetch();
 			}
 		},

--- a/server/graphql/types/basic.js
+++ b/server/graphql/types/basic.js
@@ -17,4 +17,4 @@ const Region = new GraphQLEnumType({
 
 export default {
 	Region
-}
+};

--- a/server/graphql/types/collections.js
+++ b/server/graphql/types/collections.js
@@ -34,7 +34,7 @@ const Page = new GraphQLObjectType({
 		url: {
 			type: GraphQLString,
 			resolve: (it) => {
-				return (it.sectionId ? `/stream/sectionsId/${it.sectionId}` : null)
+				return (it.sectionId ? `/stream/sectionsId/${it.sectionId}` : null);
 			}
 		},
 		title: {
@@ -65,7 +65,7 @@ const ContentByConcept = new GraphQLObjectType({
 		},
 		url: {
 			type: GraphQLString,
-			resolve: () => (null),
+			resolve: () => (null)
 		},
 		items: {
 			type: new GraphQLList(Content),
@@ -76,7 +76,7 @@ const ContentByConcept = new GraphQLObjectType({
 				genres: { type: new GraphQLList(GraphQLString) }
 			},
 			resolve: (result, {from, limit, genres}, {backend}) => {
-				return backend.contentv2(result.items, {from, limit, genres})
+				return backend.contentv2(result.items, {from, limit, genres});
 			}
 		}
 	}
@@ -86,4 +86,4 @@ export default {
 	Collection,
 	Page,
 	ContentByConcept
-}
+};

--- a/server/graphql/types/content.js
+++ b/server/graphql/types/content.js
@@ -114,7 +114,7 @@ const ContentV1 = new GraphQLObjectType({
 		primaryTag: {
 			type: Concept,
 			resolve: (content) => {
-				return articlePrimaryTag(content.item.metadata)
+				return articlePrimaryTag(content.item.metadata);
 			}
 		},
 		primaryImage: {
@@ -176,7 +176,7 @@ const ContentV2 = new GraphQLObjectType({
 		primaryTag: {
 			type: Concept,
 			resolve: (content) => {
-				return articlePrimaryTag(content.item.metadata)
+				return articlePrimaryTag(content.item.metadata);
 			}
 		},
 		primaryImage: {
@@ -219,4 +219,4 @@ export default {
 	Image,
 	ContentV1,
 	ContentV2
-}
+};

--- a/server/lib/graphql.js
+++ b/server/lib/graphql.js
@@ -2,7 +2,7 @@ import {graphql} from 'graphql';
 
 import schema from '../graphql/schema';
 import backend from '../graphql/backend';
-import fastFtFeed from '../graphql/fastFtFeed';
+import fastFtFeed from '../graphql/fast-ft-feed';
 
 const fetch = (useElasticSearch) => {
 	return (query) => {

--- a/server/lib/graphql.js
+++ b/server/lib/graphql.js
@@ -2,12 +2,16 @@ import {graphql} from 'graphql';
 
 import schema from '../graphql/schema';
 import backend from '../graphql/backend';
+import fastFtFeed from '../graphql/fastFtFeed';
 
-const fetch = (backend) => {
+const fetch = (useElasticSearch) => {
 	return (query) => {
 		const then = new Date().getTime();
 
-		return graphql(schema, query, {backend: backend})
+		return graphql(schema, query, {
+			backend: backend(useElasticSearch),
+			fastFtFeed: fastFtFeed(useElasticSearch)
+		})
 		.then(it => {
 			const now = new Date().getTime();
 
@@ -16,11 +20,11 @@ const fetch = (backend) => {
 
 			throw it.errors;
 		});
-	}
+	};
 };
 
-const fetchEs = fetch(backend(true));
-const fetchCapi = fetch(backend(false));
+const fetchEs = fetch(true);
+const fetchCapi = fetch(false);
 
 export default (elastic) => ({
 	fetch: (elastic ? fetchEs : fetchCapi)


### PR DESCRIPTION
Instead of polling the content API directly for FastFt updates, we can now poll the notifications API and use the response to determine whether or not any pending articles are waiting to be fetched. This should be a little friendlier to the content APIs.