### PR TITLE
Slow down fastFT polling to a minute to reduce traffic on the router

### DIFF
--- a/components/fastft/main.js
+++ b/components/fastft/main.js
@@ -25,7 +25,7 @@ const init = (el, opts) => {
 		});
 	};
 
-	setInterval(poller, 20000);
+	setInterval(poller, 60000);
 };
 
 export default {


### PR DESCRIPTION
This is a short-term solution until we come up with a better way of live updating fastFT (see #158).