### PR TITLE
Add Surrogate-Control

### DIFF
--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -11,7 +11,7 @@ export default (region) => {
 
 		res.set({
 			// needs to be private so we can vary for signed in state, ab tests, etc
-			'Cache-Control': 'max-age=0, private, no-cache'
+			'Surrogate-Control': 'max-age: 60'
 		});
 
 		graphql(useElasticSearch, mockBackend).fetch(queries.frontPage(region))


### PR DESCRIPTION
We want to serve private cache headers in public, but retain the high cache-hit ratio

https://docs.fastly.com/guides/tutorials/cache-control-tutorial