### PR TITLE
Vary in-memory cache into elasticsearch and direct fetched content

### DIFF
--- a/server/graphql/backend-adapters/capi.js
+++ b/server/graphql/backend-adapters/capi.js
@@ -8,13 +8,13 @@ class CAPI {
 	}
 
 	page(uuid, ttl = 50) {
-		return this.cache.cached(`pages.${uuid}`, ttl, () => {
+		return this.cache.cached(`${this.type}.pages.${uuid}`, ttl, () => {
 			return ApiClient.pages({ uuid: uuid });
 		});
 	}
 
 	byConcept(uuid, ttl = 50) {
-		return this.cache.cached(`byconcept.${uuid}`, ttl, () => {
+		return this.cache.cached(`${this.type}.byconcept.${uuid}`, ttl, () => {
 			return ApiClient.contentAnnotatedBy({
 				uuid: uuid,
 				useElasticSearch: this.elasticSearch
@@ -23,7 +23,7 @@ class CAPI {
 	}
 
 	search(query, ttl = 50) {
-		return this.cache.cached(`search.${query}`, ttl, () => {
+		return this.cache.cached(`${this.type}.search.${query}`, ttl, () => {
 			return ApiClient.searchLegacy({
 				query: query,
 				useLegacyContent: true,
@@ -33,7 +33,7 @@ class CAPI {
 	}
 
 	contentv1(uuids) {
-		return this.cache.cached(`contentv1.${uuids.join('_')}`, 50, () => {
+		return this.cache.cached(`${this.type}.contentv1.${uuids.join('_')}`, 50, () => {
 			return ApiClient.contentLegacy({
 				uuid: uuids,
 				useElasticSearch: this.elasticSearch
@@ -42,7 +42,7 @@ class CAPI {
 	}
 
 	contentv2(uuids) {
-		return this.cache.cached(`contentv2.${uuids.join('_')}`, 50, () => {
+		return this.cache.cached(`${this.type}.contentv2.${uuids.join('_')}`, 50, () => {
 			return ApiClient.content({
 				uuid: uuids,
 				useElasticSearch: this.elasticSearch

--- a/server/graphql/backend.js
+++ b/server/graphql/backend.js
@@ -34,8 +34,9 @@ const filterContent = ({from, limit, genres, type}, resolveType) => {
 };
 
 class Backend {
-	constructor(adapters) {
+	constructor(adapters, type) {
 		this.adapters = adapters;
+		this.type = type;
 	}
 
 	page(uuid, sectionsId, ttl = 50) {
@@ -160,8 +161,8 @@ const mockedCAPI = new MockCAPI(esCAPI);
 const mockLiveblog = new MockLiveblog(liveblog);
 
 // Elasticsearch & direct CAPI Backends
-const esBackend = new Backend({fastFT: esFastFT, capi: esCAPI, popular: popular, liveblog: liveblog, videos: playlist});
-const capiBackend = new Backend({fastFT: capiFastFT, capi: directCAPI, popular: popular, liveblog: liveblog, videos: playlist});
+const esBackend = new Backend({fastFT: esFastFT, capi: esCAPI, popular: popular, liveblog: liveblog, videos: playlist}, 'elasticsearch');
+const capiBackend = new Backend({fastFT: capiFastFT, capi: directCAPI, popular: popular, liveblog: liveblog, videos: playlist}, 'direct');
 
 // Mock backend
 const mockBackend = new Backend({fastFT: esFastFT, capi: mockedCAPI, popular: popular, liveblog: mockLiveblog, videos: playlist});

--- a/server/lib/graphql.js
+++ b/server/lib/graphql.js
@@ -13,7 +13,7 @@ const fetch = (backend) => {
 		.then(it => {
 			const now = new Date().getTime();
 
-			console.log("Graphql responded in", now - then, "ms");
+			console.log("Graphql (", backend.type, ") responded in", now - then, "ms");
 			if(it.data) { return it.data; }
 
 			throw it.errors;


### PR DESCRIPTION
This re-enables the use of `elasticSearchItemGet` toggle.