### PR TITLE
Separate build-production out into its own step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ install:
 verify:
 	nbt verify
 
-# FIXME enable verify for ES6 + JSX, test: verify build-production unit-test
-test: build-production
+# FIXME enable verify for ES6 + JSX, test: verify unit-test
+test:
+	@echo "TODO: Implement tests"
 
 run:
 	nbt run


### PR DESCRIPTION
@charypar 
Making the ‘build’ step separate to the ‘test’ step