### PR TITLE
Fix tag styles on related stories

### DIFF
--- a/client/components/story-card/main.scss
+++ b/client/components/story-card/main.scss
@@ -46,10 +46,12 @@
 	margin-right: 5px;
 	margin-bottom: 5px;
 	@include nTypeBravoSize(4);
-	a {
+	&.story-card__link,
+	.story-card__link {
 		@include nLinksTopic();
 	}
 }
+
 .story-card__summary {
 	@include nTypeDelta(3);
 	line-height: 1;

--- a/views/partials/carousel-card.html
+++ b/views/partials/carousel-card.html
@@ -11,7 +11,7 @@
 	{{/if}}
 	<div class="carousel-card__content">
 		<h2 class="story-card__taxon">
-			<a href="{{primaryTag.url}}" data-trackable="primary-tag" class="story-card--link" tabindex="0" aria-label="Topic: {{primaryTag.name}}">
+			<a href="{{primaryTag.url}}" data-trackable="primary-tag" class="story-card__link" tabindex="0" aria-label="Topic: {{primaryTag.name}}">
 				{{primaryTag.name}}
 			</a>
 		</h2>

--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -36,8 +36,8 @@
 		<div class="story-card__related" data-trackable="related-links" tabindex="0" role="group" aria-label="Related links">
 			{{#slice relatedContent limit=3}}
 				<article class="story-card__related-link" aria-labelledby="{{id}}-title" tabindex="0" role="article">
-					<a href="{{{primaryTag.url}}}" data-trackable="primary-tag" class="story-card__link">
-						<span class="story-card__taxon" aria-label="Topic: {{primaryTag.name}}">{{primaryTag.name}}</span></a><span aria-hidden="true">|</span>
+					<a href="{{{primaryTag.url}}}" data-trackable="primary-tag" class="story-card__taxon story-card__link">
+						<span aria-label="Topic: {{primaryTag.name}}">{{primaryTag.name}}</span></a><span aria-hidden="true">|</span>
 					<a href="/{{id}}" data-trackable="title" role="heading"><span id="{{id}}-title">{{title}}</span></a>
 				</article>
 			{{/slice}}


### PR DESCRIPTION
/cc @charypar @imranolas 

Sorry I broke this on Friday!

Before:

<img width="893" alt="screen shot 2015-09-01 at 13 08 47" src="https://cloud.githubusercontent.com/assets/1978880/9603731/9d4190a4-50aa-11e5-839a-668f4be5204d.png">


After: 

<img width="932" alt="screen shot 2015-09-01 at 13 06 55" src="https://cloud.githubusercontent.com/assets/1978880/9603733/a2049b04-50aa-11e5-8f9c-127ad8a26bf9.png">
