### PR TITLE
De-duplicate backend request through the cache layer

### DIFF
--- a/server/graphql/cache.js
+++ b/server/graphql/cache.js
@@ -4,6 +4,7 @@ class Cache {
 	constructor(staleTtl) {
 		// in-memory content cache
 		this.contentCache = {};
+		this.requestMap = {};
 
 		const sweeper = () => {
 			const now = (new Date().getTime()) / 1000;
@@ -19,6 +20,10 @@ class Cache {
 		setInterval(sweeper, 60 * 1000);
 	}
 
+	clear(key) {
+		delete this.contentCache[key];
+	}
+
 	// Caching wrapper. Always returns a promise, when cache expires
 	// returns stale data immediately and fetches fresh one
 	cached(key, ttl, fetcher) {
@@ -31,8 +36,18 @@ class Cache {
 		// we have fresh data
 		if(expire > now && data) { return Promise.resolve(data); }
 
-		// fetch fresh data
-		const eventualData = fetcher()
+		// we don't have fresh data, fetch it
+		const eventualData = this._fetch(key, now, ttl, fetcher);
+
+		// return stale data or promise of fresh data
+		return (data ? Promise.resolve(data) : eventualData);
+	}
+
+	_fetch(key, now, ttl, fetcher) {
+		if(this.requestMap[key])
+			return this.requestMap[key];
+
+		this.requestMap[key] = fetcher()
 		.then((it) => {
 			let expireTime = now + ttl;
 
@@ -41,11 +56,15 @@ class Cache {
 				data: it
 			};
 
+			delete this.requestMap[key];
+
 			return it;
+		})
+		.catch((e) => {
+			delete this.requestMap[key];
 		});
 
-		// return stale data or promise of fresh data
-		return (data ? Promise.resolve(data) : eventualData);
+		return this.requestMap[key];
 	}
 }
 

--- a/test/server/graphql/cache.test.js
+++ b/test/server/graphql/cache.test.js
@@ -1,0 +1,89 @@
+import fetch from 'isomorphic-fetch';
+import {Promise} from 'es6-promise';
+global.fetch = fetch;
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+import Cache from '../../../server/graphql/cache';
+
+
+describe('GraphQL Cache', () => {
+	const cache = new Cache(10);
+	const fetcher = () => {
+		return Promise.resolve('fresh');
+	};
+	const fail = () => {
+		return Promise.reject('OMG');
+	};
+
+
+	describe('#cached', () => {
+		it('fetches fresh data when nothing is cached', () => {
+			expect(cache.cached('test-key-1', 1, fetcher)).to.eventually.eq('fresh');
+		});
+
+		it('returns cached data when fresh', () => {
+			return cache.cached('test-key-2', 10, () => Promise.resolve('orig'))
+			.then(() => {
+				return cache.cached('test-key-2', 10, fetcher)
+			})
+			.then((it) => {
+				expect(it).to.eq('orig');
+			});
+		});
+
+		it('returns stale data when expired', () => {
+			return cache.cached('test-key-3', -1, () => Promise.resolve('stale'))
+			.then(() => {
+				return cache.cached('test-key-3', 10, fetcher);
+			})
+			.then((it) => {
+				expect(it).to.eq('stale')
+			})
+		});
+
+		it('fetches new data when cache expires', () => {
+			return cache.cached('test-key-4', -10, () => Promise.resolve('stale'))
+			.then((it) => {
+				return cache.cached('test-key-4', 10, fetcher);
+			})
+			.then((it) => {
+				expect(it).to.eq('stale');
+				return cache.cached('test-key-4', 10, () => Promise.resolve('too fresh'));
+			})
+			.then((it) => {
+				expect(it).to.eq('fresh');
+			})
+		});
+
+		it('only fetches new data once at a time when cache expires', () => {
+			let p1 = cache.cached('test-key-5', 10, fetcher);
+			let p2 = cache.cached('test-key-5', 10, fetcher);
+
+			// both should be the same promise
+			expect(p1).to.eq(p2);
+		});
+
+		it('clean up finished and failed fetches', () => {
+			let p3 = null;
+			let p1 = cache.cached('test-key-6', -1, fail)
+
+			return p1.then(() => {
+				let p2 = cache.cached('test-key-6', -1, fetcher)
+
+				return p2.then(() => {
+					cache.clear('test-key-6');
+					p3 = cache.cached('test-key-6', 10, fetcher);
+
+					// now they shouldn't be the same promise
+					expect(p1).to.not.equal(p2);
+					expect(p1).to.not.equal(p3);
+					expect(p2).to.not.equal(p3);
+				})
+			});
+		});
+	});
+});


### PR DESCRIPTION
This should hopefully stop us flooding the backend APIs every time when the cache expires between the first request for expired content and successful fetching of a fresh version of it (which can be up to a few seconds and translate into a lot of unnecessary extra load). This is suspected to also cause sudden memory spikes (#241). 

Also covered the cache with unit tests.

/cc @wheresrhys @matthew-andrews 