### PR TITLE
Fix mobile tabs not appearing (fix #245)

### DIFF
--- a/client/main.scss
+++ b/client/main.scss
@@ -128,9 +128,10 @@ body {
 		}
 	}
 
-	// Top tabs (News, fastFT)
-	.nh-header-tabs__tablist {
-		display: none;
+	@include oGridRespondTo(L) {
+		.nh-header-tabs__tablist {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Caused by linter insisting on rule order that's breaking the CSS override order. Ahh, CSS.