### PR TITLE
Highlight dom path based on hash

### DIFF
--- a/client/components/highlight-dom-path/main.js
+++ b/client/components/highlight-dom-path/main.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = () => {
+
+	var domPath = document.location.hash.split('#').pop();
+	if (/^domPath:/.test(domPath)) {
+		var selector = domPath
+			.replace(/^domPath:/, '')
+			.split(' | ')
+			.map(part => `[data-trackable="${part}"]`)
+			.join(' ');
+		[...document.querySelectorAll(selector)]
+			.forEach(el => el.classList.add('dom-path-highlight'));
+	}
+
+}

--- a/client/components/highlight-dom-path/main.scss
+++ b/client/components/highlight-dom-path/main.scss
@@ -1,0 +1,4 @@
+.dom-path-highlight {
+	background-color: rgba(255, 0, 0, 0.5);
+}
+

--- a/client/main.js
+++ b/client/main.js
@@ -1,5 +1,6 @@
 import fastFT from '../components/fastft/main';
 import headerTabs from './components/header-tabs/main';
+import highlightDomPath from './components/highlight-dom-path/main';
 
 import layout from 'n-layout';
 import setup from 'next-js-setup';
@@ -29,4 +30,5 @@ setup.bootstrap(({flags}) => {
 	}
 	oDate.init();
 	prompts.init();
+	highlightDomPath();
 });

--- a/client/main.scss
+++ b/client/main.scss
@@ -32,6 +32,7 @@ $_next-ui-setup-first-pass: false;
 @import "components/header-tabs/main";
 @import "components/video/main";
 @import "components/ads/main";
+@import "components/highlight-dom-path/main";
 
 @import "icons";
 

--- a/server/graphql/backend.js
+++ b/server/graphql/backend.js
@@ -13,7 +13,7 @@ import articleGenres from 'ft-next-article-genre';
 
 // internal content filtering logic shared for ContentV1 and ContentV2
 const filterContent = ({from, limit, genres, type}, resolveType) => {
-	return (items) => {
+	return (items = []) => {
 		if(genres && genres.length) {
 			items = items.filter(it => genres.indexOf(articleGenres(it.item.metadata, {requestedProp: 'editorialTone'})) > -1);
 		}


### PR DESCRIPTION
e.g. `/uk#domPath:lead-today | story | title | main-link` displays 

![screen shot 2015-09-09 at 15 40 24](https://cloud.githubusercontent.com/assets/74132/9764841/203d1c08-5709-11e5-8cce-7ae80b12bdab.jpeg)

Will be useful for tying the CTA dashboard to actual components