### PR TITLE
Stale cache handling

### DIFF
--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -11,7 +11,7 @@ export default (region) => {
 
 		res.set({
 			// needs to be private so we can vary for signed in state, ab tests, etc
-			'Surrogate-Control': 'max-age=60'
+			'Surrogate-Control': 'max-age=60,stale-while-revalidate,stale-if-error=259200'
 		});
 
 		graphql(useElasticSearch, mockBackend, { flags: res.locals.flags }).fetch(queries.frontPage(region))

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -11,7 +11,7 @@ export default (region) => {
 
 		res.set({
 			// needs to be private so we can vary for signed in state, ab tests, etc
-			'Surrogate-Control': 'max-age=60,stale-while-revalidate=1,stale-if-error=259200'
+			'Surrogate-Control': 'max-age=60,stale-while-revalidate=6,stale-if-error=259200'
 		});
 
 		graphql(useElasticSearch, mockBackend, { flags: res.locals.flags }).fetch(queries.frontPage(region))

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -11,7 +11,7 @@ export default (region) => {
 
 		res.set({
 			// needs to be private so we can vary for signed in state, ab tests, etc
-			'Surrogate-Control': 'max-age=60,stale-while-revalidate,stale-if-error=259200'
+			'Surrogate-Control': 'max-age=60,stale-while-revalidate=1,stale-if-error=259200'
 		});
 
 		graphql(useElasticSearch, mockBackend, { flags: res.locals.flags }).fetch(queries.frontPage(region))


### PR DESCRIPTION
Instructs the cache to update the content every 2 minutes but if the origin is down then show stale content for 3 days.

https://docs.fastly.com/guides/performance-tuning/serving-stale-content