### PR TITLE
Handle change to list API

### DIFF
--- a/server/graphql/fixtures/lists.js
+++ b/server/graphql/fixtures/lists.js
@@ -6,15 +6,15 @@ export default {
 		publishedDate: '2015-06-24T09:44:00.000Z',
 		items: [
 			{
-				id: 'http://api.ft.com/thing/3600a424-199c-11e5-a130-2e7db721f996',
+				id: 'http://api.ft.com/things/3600a424-199c-11e5-a130-2e7db721f996',
 				apiUrl: 'http://api.ft.com/content/3600a424-199c-11e5-a130-2e7db721f996'
 			},
 			{
-				id: 'http://api.ft.com/thing/dc12711c-19ab-11e5-a130-2e7db721f996',
+				id: 'http://api.ft.com/things/dc12711c-19ab-11e5-a130-2e7db721f996',
 				apiUrl: 'http://api.ft.com/content/dc12711c-19ab-11e5-a130-2e7db721f996'
 			},
 			{
-				id: 'http://api.ft.com/thing/265ceb78-15ae-11e5-8e6a-00144feabdc0',
+				id: 'http://api.ft.com/things/265ceb78-15ae-11e5-8e6a-00144feabdc0',
 				apiUrl: 'http://api.ft.com/content/265ceb78-15ae-11e5-8e6a-00144feabdc0'
 			}
 		]

--- a/server/graphql/types/collections.js
+++ b/server/graphql/types/collections.js
@@ -123,7 +123,7 @@ const List = new GraphQLObjectType({
 			resolve: (result, args, {rootValue: {backend}}) => {
 				if(!result.items || result.items.length < 1) { return []; }
 
-				return backend.contentv1(result.items.map(result => result.id.replace('http://api.ft.com/thing/', '')), args);
+				return backend.contentv1(result.items.map(result => result.id.replace(/http:\/\/api\.ft\.com\/things?\//, '')), args);
 			}
 		}
 	}

--- a/test/server/graphql/fixtures/list.js
+++ b/test/server/graphql/fixtures/list.js
@@ -5,47 +5,47 @@ export default {
 	publishedDate: '2015-06-24T09:44:00.000Z',
 	items: [
 		{
-			id: 'http://api.ft.com/thing/3600a424-199c-11e5-a130-2e7db721f996',
+			id: 'http://api.ft.com/things/3600a424-199c-11e5-a130-2e7db721f996',
 			apiUrl: 'http://api.ft.com/content/3600a424-199c-11e5-a130-2e7db721f996'
 		},
 		{
-			id: 'http://api.ft.com/thing/dc12711c-19ab-11e5-a130-2e7db721f996',
+			id: 'http://api.ft.com/things/dc12711c-19ab-11e5-a130-2e7db721f996',
 			apiUrl: 'http://api.ft.com/content/dc12711c-19ab-11e5-a130-2e7db721f996'
 		},
 		{
-			id: 'http://api.ft.com/thing/265ceb78-15ae-11e5-8e6a-00144feabdc0',
+			id: 'http://api.ft.com/things/265ceb78-15ae-11e5-8e6a-00144feabdc0',
 			apiUrl: 'http://api.ft.com/content/265ceb78-15ae-11e5-8e6a-00144feabdc0'
 		},
 		{
-			id: 'http://api.ft.com/thing/65e3be20-1991-11e5-8201-cbdb03d71480',
+			id: 'http://api.ft.com/things/65e3be20-1991-11e5-8201-cbdb03d71480',
 			apiUrl: 'http://api.ft.com/content/65e3be20-1991-11e5-8201-cbdb03d71480'
 		},
 		{
-			id: 'http://api.ft.com/thing/d6029592-0eb9-11e5-8aca-00144feabdc0',
+			id: 'http://api.ft.com/things/d6029592-0eb9-11e5-8aca-00144feabdc0',
 			apiUrl: 'http://api.ft.com/content/d6029592-0eb9-11e5-8aca-00144feabdc0'
 		},
 		{
-			id: 'http://api.ft.com/thing/ffa6355a-0ac4-11e5-a8e8-00144feabdc0',
+			id: 'http://api.ft.com/things/ffa6355a-0ac4-11e5-a8e8-00144feabdc0',
 			apiUrl: 'http://api.ft.com/content/ffa6355a-0ac4-11e5-a8e8-00144feabdc0'
 		},
 		{
-			id: 'http://api.ft.com/thing/fac4ae4c-146d-11e5-ad6e-00144feabdc0',
+			id: 'http://api.ft.com/things/fac4ae4c-146d-11e5-ad6e-00144feabdc0',
 			apiUrl: 'http://api.ft.com/content/fac4ae4c-146d-11e5-ad6e-00144feabdc0'
 		},
 		{
-			id: 'http://api.ft.com/thing/d42d3c68-141d-11e5-abda-00144feabdc0',
+			id: 'http://api.ft.com/things/d42d3c68-141d-11e5-abda-00144feabdc0',
 			apiUrl: 'http://api.ft.com/content/d42d3c68-141d-11e5-abda-00144feabdc0'
 		},
 		{
-			id: 'http://api.ft.com/thing/9ef3b4e2-0e2c-11e5-8ce9-00144feabdc0',
+			id: 'http://api.ft.com/things/9ef3b4e2-0e2c-11e5-8ce9-00144feabdc0',
 			apiUrl: 'http://api.ft.com/content/9ef3b4e2-0e2c-11e5-8ce9-00144feabdc0'
 		},
 		{
-			id: 'http://api.ft.com/thing/3dfa2168-0e8f-11e5-9ae0-00144feabdc0',
+			id: 'http://api.ft.com/things/3dfa2168-0e8f-11e5-9ae0-00144feabdc0',
 			apiUrl: 'http://api.ft.com/content/3dfa2168-0e8f-11e5-9ae0-00144feabdc0'
 		},
 		{
-			id: 'http://api.ft.com/thing/d5a0c9ba-1559-11e5-a587-00144feabdc0',
+			id: 'http://api.ft.com/things/d5a0c9ba-1559-11e5-a587-00144feabdc0',
 			apiUrl: 'http://api.ft.com/content/d5a0c9ba-1559-11e5-a587-00144feabdc0'
 		}
 	]


### PR DESCRIPTION
`id` is changing to `things`, e.g. `http://api.ft.com/things/a8573532-65bf-11e5-97e9-7f0bf5e7177b` in list api response

http://git.svc.ft.com:8080/projects/CP/repos/document-store-api/pull-requests/18/diff

