### PR TITLE
[Ready] Layout prototype UI

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -9,6 +9,7 @@ import nVideo from 'n-video';
 import prompts from 'n-message-prompts';
 
 import fastFT from '../components/fastft/main';
+import Layout from '../components/layout/main';
 
 import './main.scss';
 
@@ -32,4 +33,9 @@ setup.bootstrap(({flags}) => {
 	prompts.init();
 	highlightDomPath();
 	scrollDepth.init(flags);
+
+	const layoutContainer = document.getElementById('main-body');
+	const content = JSON.parse(layoutContainer.dataset.mainContent);
+
+	Layout.init(layoutContainer, content);
 });

--- a/client/main.js
+++ b/client/main.js
@@ -10,6 +10,7 @@ import prompts from 'n-message-prompts';
 
 import fastFT from '../components/fastft/main';
 import Layout from '../components/layout/main';
+import LayoutOverlay from '../components/layout-overlay/main';
 
 import './main.scss';
 
@@ -35,7 +36,11 @@ setup.bootstrap(({flags}) => {
 	scrollDepth.init(flags);
 
 	const layoutContainer = document.getElementById('main-body');
-	const content = JSON.parse(layoutContainer.dataset.mainContent);
+	const content = layoutContainer ? JSON.parse(layoutContainer.dataset.mainContent) : {};
 
 	Layout.init(layoutContainer, content);
+
+	const layoutOverlayContainer = document.getElementById('layout-overlay-container');
+
+	LayoutOverlay.init(layoutOverlayContainer);
 });

--- a/client/main.js
+++ b/client/main.js
@@ -43,7 +43,6 @@ setup.bootstrap(({flags}) => {
 	const layoutOverlayContainer = document.getElementById('layout-overlay-container');
 
 	LayoutOverlay.init(layoutOverlayContainer, (newLayout) => {
-		console.log(newLayout);
 		Layout.render(newLayout);
 		LayoutOverlay.render(newLayout);
 	});

--- a/client/main.js
+++ b/client/main.js
@@ -43,6 +43,8 @@ setup.bootstrap(({flags}) => {
 	const layoutOverlayContainer = document.getElementById('layout-overlay-container');
 
 	LayoutOverlay.init(layoutOverlayContainer, (newLayout) => {
+		console.log(newLayout);
 		Layout.render(newLayout);
+		LayoutOverlay.render(newLayout);
 	});
 });

--- a/client/main.js
+++ b/client/main.js
@@ -42,5 +42,7 @@ setup.bootstrap(({flags}) => {
 
 	const layoutOverlayContainer = document.getElementById('layout-overlay-container');
 
-	LayoutOverlay.init(layoutOverlayContainer);
+	LayoutOverlay.init(layoutOverlayContainer, (newLayout) => {
+		Layout.render(newLayout);
+	});
 });

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -37,7 +37,7 @@ class Card extends Component {
 				<Title title={article.title} href={'/content/' + article.id} size={titleSize} />
 				{standFirst ? <Standfirst article={article} style={article.primaryTag.taxonomy} size={standFirst} /> : null}
 				{showImage ? <Image article={article} display={image} /> : null}
-				{related ? <Related articles={article.relatedContent} /> : null}
+				{related ? <Related articles={article.relatedContent} limit={this.props.related} /> : null}
 			</article>
 		);
 	}

--- a/components/card/related/related.js
+++ b/components/card/related/related.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 
 export default class Related extends Component {
 	render() {
-		const relatedEls = this.props.articles.map(related => (
+		const relatedEls = this.props.articles.slice(0, this.props.limit).map(related => (
 			<li className="card__related-item" key={related.id}>
 				<a href={'/content/' + related.id} className="card__related-item__link" data-trackable="related">{related.title}</a>
 			</li>

--- a/components/card/tag/main.scss
+++ b/components/card/tag/main.scss
@@ -1,7 +1,9 @@
+@import 'next-sass-setup/main';
+
 .card__tag {
 	font-family: $n-type-sans-serif;
 	font-weight: oFontsWeight(light);
-	color: #4a90e2;
+	color: getColor(claret);
 	border-bottom: 0;
 }
 
@@ -20,14 +22,16 @@
 }
 
 .card__tag--authors {
-	color: #fbba2d;
+	color: getColor(claret);
 
 	&:before {
-		content: '“';
-		color: #c3bdb6;
+		@include nTypeDelta(1);
 		font-size: 60px;
+		color: #c3bdb6;
+		content: '“';
+		display: inline-block;
 		line-height: 0;
 		vertical-align: bottom;
-		margin-right: 5px;
+		margin: 0 10px -8px -5px;
 	}
 }

--- a/components/fast-ft/fast-ft-item.js
+++ b/components/fast-ft/fast-ft-item.js
@@ -1,11 +1,10 @@
 import React, {Component} from 'react';
-
-import dateFormat from 'dateformat';
+import {format as dateFormat} from 'o-date';
 
 class FastFtItem extends Component {
 	render() {
 		const article = this.props.article;
-		const time = dateFormat(article.lastPublished, 'H:MMtt');
+		const time = dateFormat(article.lastPublished, 'H:mm a');
 		return (
 			<div className="fast-ft__item">
 				<time className="fast-ft__time" datetime={article.lastPublished}>{time}</time>

--- a/components/fast-ft/fast-ft.js
+++ b/components/fast-ft/fast-ft.js
@@ -3,7 +3,7 @@ import FastFtItem from './fast-ft-item';
 
 class FastFt extends Component {
 	render() {
-		const articleEls = this.props.articles.slice(0, 6).map(article => <li key={article.id}><FastFtItem article={article} /></li>);
+		const articleEls = this.props.articles.slice(0, 7).map(article => <li key={article.id}><FastFtItem article={article} /></li>);
 		return (
 			<div className="fast-ft-wrapper">
 				<div className="fast-ft">

--- a/components/layout-overlay/card-editor/card-editor.js
+++ b/components/layout-overlay/card-editor/card-editor.js
@@ -1,6 +1,19 @@
 import React, {Component} from 'react';
 
 export default class CardEditor extends Component {
+	change(key) {
+		return (e) => {
+			const newValue = e.target.value;
+			let newCard = Object.assign({}, this.props.card);
+			if(newValue === 'none')
+				delete newCard[key];
+			else
+				newCard[key] = newValue;
+
+			this.props.onChange(newCard);
+		};
+	}
+
 	render() {
 		return (
 			<form className="card-editor">
@@ -11,13 +24,16 @@ export default class CardEditor extends Component {
 						data-trackable="card-column"
 						value={this.props.card.column}
 						min={this.props.minColumn}
-						max={this.props.maxColumn} />
+						max={this.props.maxColumn}
+						onChange={this.change('column')} />
 					{ this.props.showWidth ? <label>Width</label> : null }
-					{ this.props.showWidth ? <input type="number" data-trackable="card-width" value={this.props.card.width || 2} /> : null }
+					{ this.props.showWidth ?
+						<input type="number" data-trackable="card-width" value={this.props.card.width || 2} onChange={this.change('width')} />
+						: null }
 				</p>
 				<p>
 					<label>Tag size</label>
-					<select data-trackable="card-tag-size" value={this.props.card.tagSize}>
+					<select data-trackable="card-tag-size" value={this.props.card.tagSize} onChange={this.change('tagSize')}>
 						<option value="large">Large</option>
 						<option value="medium">Medium</option>
 						<option value="small">Small</option>
@@ -25,7 +41,7 @@ export default class CardEditor extends Component {
 				</p>
 				<p>
 					<label>Title size</label>
-					<select data-trackable="card-title-size" value={this.props.card.titleSize}>
+					<select data-trackable="card-title-size" value={this.props.card.titleSize} onChange={this.change('titleSize')}>
 						<option value="large">Large</option>
 						<option value="medium">Medium</option>
 						<option value="small">Small</option>
@@ -34,7 +50,7 @@ export default class CardEditor extends Component {
 				</p>
 				<p>
 					<label>Stand first</label>
-					<select data-trackable="card-stand-first" value={this.props.card.standFirst || 'none'}>
+					<select data-trackable="card-stand-first" value={this.props.card.standFirst || 'none'} onChange={this.change('standFirst')}>
 						<option value="large">Large</option>
 						<option value="medium">Medium</option>
 						<option value="none">Hidden</option>
@@ -42,7 +58,7 @@ export default class CardEditor extends Component {
 				</p>
 				<p>
 					<label>Image</label>
-					<select data-trackable="card-image" value={this.props.card.image || 'none'}>
+					<select data-trackable="card-image" value={this.props.card.image || 'none'} onChange={this.change('image')}>
 						<option value="always">Always</option>
 						<option value="desktop">Desktop only</option>
 						<option value="none">Hidden</option>
@@ -50,7 +66,7 @@ export default class CardEditor extends Component {
 				</p>
 				<p>
 					<label>Related Stories</label>
-					<input type="number" data-trackable="card-related-stories" value={this.props.card.related || 0} />
+					<input type="number" data-trackable="card-related-stories" value={this.props.card.related || 0} onChange={this.change('related')} />
 				</p>
 			</form>
 		);

--- a/components/layout-overlay/card-editor/card-editor.js
+++ b/components/layout-overlay/card-editor/card-editor.js
@@ -6,9 +6,14 @@ export default class CardEditor extends Component {
 			<form className="card-editor">
 				<p className="card-editor__overview">
 					<label>Column</label>
-					<input type="number" data-trackable="card-column" value={this.props.card.column} />
-					<label>Width</label>
-					<input type="number" data-trackable="card-width" value={this.props.card.width} />
+					<input
+						type="number"
+						data-trackable="card-column"
+						value={this.props.card.column}
+						min={this.props.minColumn}
+						max={this.props.maxColumn} />
+					{ this.props.showWidth ? <label>Width</label> : null }
+					{ this.props.showWidth ? <input type="number" data-trackable="card-width" value={this.props.card.width || 2} /> : null }
 				</p>
 				<p>
 					<label>Tag size</label>

--- a/components/layout-overlay/card-editor/card-editor.js
+++ b/components/layout-overlay/card-editor/card-editor.js
@@ -1,0 +1,53 @@
+import React, {Component} from 'react';
+
+export default class CardEditor extends Component {
+	render() {
+		return (
+			<form className="card-editor">
+				<p className="card-editor__overview">
+					<label>Column</label>
+					<input type="number" data-trackable="card-column" value={this.props.card.column} />
+					<label>Width</label>
+					<input type="number" data-trackable="card-width" value={this.props.card.width} />
+				</p>
+				<p>
+					<label>Tag size</label>
+					<select data-trackable="card-tag-size" value={this.props.card.tagSize}>
+						<option value="large">Large</option>
+						<option value="medium">Medium</option>
+						<option value="small">Small</option>
+					</select>
+				</p>
+				<p>
+					<label>Title size</label>
+					<select data-trackable="card-title-size" value={this.props.card.titleSize}>
+						<option value="large">Large</option>
+						<option value="medium">Medium</option>
+						<option value="small">Small</option>
+						<option value="tiny">Tiny</option>
+					</select>
+				</p>
+				<p>
+					<label>Stand first</label>
+					<select data-trackable="card-stand-first" value={this.props.card.standFirst || 'none'}>
+						<option value="large">Large</option>
+						<option value="medium">Medium</option>
+						<option value="none">Hidden</option>
+					</select>
+				</p>
+				<p>
+					<label>Image</label>
+					<select data-trackable="card-image" value={this.props.card.image || 'none'}>
+						<option value="always">Always</option>
+						<option value="desktop">Desktop only</option>
+						<option value="none">Hidden</option>
+					</select>
+				</p>
+				<p>
+					<label>Related Stories</label>
+					<input type="number" data-trackable="card-related-stories" value={this.props.card.related || 0} />
+				</p>
+			</form>
+		);
+	}
+}

--- a/components/layout-overlay/card-editor/main.scss
+++ b/components/layout-overlay/card-editor/main.scss
@@ -1,0 +1,42 @@
+.card-editor {
+	@include nTypeAlpha(4);
+	margin: 0.5em;
+	padding: 0.3em;
+	background-color: rgba(#ffffff, 0.2);
+	border-radius: 3px;
+}
+
+.card-editor label {
+	display: inline-block;
+	width: 40%;
+}
+
+.card-editor select {
+	width: 50%;
+}
+
+.card-editor input {
+	width: 50%;
+	color: black;
+}
+
+.card-editor p {
+	padding-bottom: 0.2em;
+}
+
+.card-editor .card-editor__overview {
+	padding-bottom: 0.5em;
+
+	label {
+		width: 20%;
+		padding-left: 0.5em;
+
+		&:first-child {
+			padding-left: 0;
+		}
+	}
+
+	input {
+		width: 25%;
+	}
+}

--- a/components/layout-overlay/layout-overlay.js
+++ b/components/layout-overlay/layout-overlay.js
@@ -1,5 +1,7 @@
 import React, {Component} from 'react';
 
+import Section from './section/section';
+
 export default class LayoutOverlay extends Component {
 	constructor(props) {
 		super(props);
@@ -13,6 +15,14 @@ export default class LayoutOverlay extends Component {
 	}
 
 	render() {
+		const sections = this.props.layout.map(section => {
+			return (
+				<li key={section.id}>
+					<Section title={section.title} cards={section.cards} />
+				</li>
+			)
+		});
+
 		return (
 			<aside className={'layout-overlay layout-overlay--' + (this.state.expanded ? 'expanded' : 'collapsed')}>
 				<a href="#" className="layout-overlay__toggle" onClick={this.toggle.bind(this)} data-trackable="overlay-toggle">
@@ -22,6 +32,9 @@ export default class LayoutOverlay extends Component {
 				</a>
 				<div className="layout-overlay__body">
 					<h2>Layout Configuration</h2>
+					<ul className="layout-overlay__sections">
+						{sections}
+					</ul>
 				</div>
 			</aside>
 		);

--- a/components/layout-overlay/layout-overlay.js
+++ b/components/layout-overlay/layout-overlay.js
@@ -14,10 +14,10 @@ export default class LayoutOverlay extends Component {
 		this.setState({expanded: !this.state.expanded});
 	}
 
-	updateCards(idx) {
+	updateCards(sectionIndex) {
 		return (newCards) => {
 			const newLayout = this.props.layout;
-			newLayout[idx].cards = newCards;
+			newLayout[sectionIndex].cards = newCards;
 
 			this.props.onChange(newLayout);
 		}

--- a/components/layout-overlay/layout-overlay.js
+++ b/components/layout-overlay/layout-overlay.js
@@ -14,11 +14,20 @@ export default class LayoutOverlay extends Component {
 		this.setState({expanded: !this.state.expanded});
 	}
 
+	updateCards(idx) {
+		return (newCards) => {
+			const newLayout = this.props.layout;
+			newLayout[idx].cards = newCards;
+
+			this.props.onChange(newLayout);
+		}
+	}
+
 	render() {
-		const sections = this.props.layout.map(section => {
+		const sections = this.props.layout.map((section, idx) => {
 			return (
 				<li key={section.id}>
-					<Section title={section.title} cards={section.cards} />
+					<Section title={section.title} cards={section.cards} onCardsChange={this.updateCards(idx)} />
 				</li>
 			)
 		});

--- a/components/layout-overlay/layout-overlay.js
+++ b/components/layout-overlay/layout-overlay.js
@@ -1,0 +1,29 @@
+import React, {Component} from 'react';
+
+export default class LayoutOverlay extends Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {expanded: false};
+	}
+
+	toggle(e) {
+		e.preventDefault();
+		this.setState({expanded: !this.state.expanded});
+	}
+
+	render() {
+		return (
+			<aside className={'layout-overlay layout-overlay--' + (this.state.expanded ? 'expanded' : 'collapsed')}>
+				<a href="#" className="layout-overlay__toggle" onClick={this.toggle.bind(this)} data-trackable="overlay-toggle">
+					<span className="n-util-visually-hidden">
+						{this.state.expanded ? 'hide' : 'show'}
+					</span>
+				</a>
+				<div className="layout-overlay__body">
+					<h2>Layout Configuration</h2>
+				</div>
+			</aside>
+		);
+	}
+}

--- a/components/layout-overlay/main.js
+++ b/components/layout-overlay/main.js
@@ -4,10 +4,12 @@ import ReactDOM from 'react-dom';
 import LayoutOverlay from './layout-overlay';
 import './main.scss';
 
-function init(el) {
+import initialLayout from '../layout/config';
+
+function init(el, callback) {
 	if (!el) return;
 
-	ReactDOM.render(<LayoutOverlay />, el);
+	ReactDOM.render(<LayoutOverlay layout={initialLayout} onChange={callback} />, el);
 }
 
 export default {

--- a/components/layout-overlay/main.js
+++ b/components/layout-overlay/main.js
@@ -6,12 +6,23 @@ import './main.scss';
 
 import initialLayout from '../layout/config';
 
-function init(el, callback) {
+let element;
+let callback;
+
+function init(el, cb) {
 	if (!el) return;
 
-	ReactDOM.render(<LayoutOverlay layout={initialLayout} onChange={callback} />, el);
+	element = el;
+	callback = cb;
+
+	render(initialLayout);
+}
+
+function render(layout) {
+	ReactDOM.render(<LayoutOverlay layout={layout} onChange={callback} />, element);
 }
 
 export default {
-	init: init
+	init: init,
+	render: render
 }

--- a/components/layout-overlay/main.js
+++ b/components/layout-overlay/main.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import LayoutOverlay from './layout-overlay';
+import './main.scss';
+
+function init(el) {
+	if (!el) return;
+
+	ReactDOM.render(<LayoutOverlay />, el);
+}
+
+export default {
+	init: init
+}

--- a/components/layout-overlay/main.scss
+++ b/components/layout-overlay/main.scss
@@ -1,0 +1,46 @@
+@import 'next-sass-setup/main';
+
+.layout-overlay {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 30;
+	background-color: black;
+	opacity: 0.8;
+	color: white;
+}
+
+.layout-overlay--expanded .layout-overlay__toggle {
+	@include nextIcon(arrow-right, white, 25);
+}
+
+.layout-overlay--collapsed .layout-overlay__toggle {
+	@include nextIcon(arrow-left, white, 25);
+}
+
+.layout-overlay--expanded .layout-overlay__toggle,
+.layout-overlay--collapsed .layout-overlay__toggle {
+	float: left;
+	width: 30px;
+	height: 100%;
+	background-size: 25px 25px;
+	background-position: center;
+}
+
+.layout-overlay__body {
+	display: none;
+	width: 300px;
+	height: 100%;
+	float: left;
+}
+
+.layout-overlay--expanded .layout-overlay__body {
+	display: inherit;
+}
+
+.layout-overlay__body h2 {
+	@include nTypeAlpha(2);
+	text-align: center;
+	margin: 0.5em;
+}

--- a/components/layout-overlay/main.scss
+++ b/components/layout-overlay/main.scss
@@ -1,4 +1,6 @@
 @import 'next-sass-setup/main';
+@import './section/main';
+@import './card-editor/main';
 
 .layout-overlay {
 	position: fixed;
@@ -26,6 +28,10 @@
 	height: 100%;
 	background-size: 25px 25px;
 	background-position: center;
+
+	&:hover {
+		background-color: rgba(#ffffff, 0.3);
+	}
 }
 
 .layout-overlay__body {
@@ -33,6 +39,8 @@
 	width: 300px;
 	height: 100%;
 	float: left;
+	overflow-x: hidden;
+	overflow-y: scroll;
 }
 
 .layout-overlay--expanded .layout-overlay__body {
@@ -43,4 +51,12 @@
 	@include nTypeAlpha(2);
 	text-align: center;
 	margin: 0.5em;
+}
+
+.layout-overlay__sections {
+	padding: 0;
+
+	li {
+		list-style: none;
+	}
 }

--- a/components/layout-overlay/main.scss
+++ b/components/layout-overlay/main.scss
@@ -3,7 +3,7 @@
 .layout-overlay {
 	position: fixed;
 	top: 0;
-	right: 0;
+	left: 0;
 	bottom: 0;
 	z-index: 30;
 	background-color: black;
@@ -12,16 +12,16 @@
 }
 
 .layout-overlay--expanded .layout-overlay__toggle {
-	@include nextIcon(arrow-right, white, 25);
+	@include nextIcon(arrow-left, white, 25);
 }
 
 .layout-overlay--collapsed .layout-overlay__toggle {
-	@include nextIcon(arrow-left, white, 25);
+	@include nextIcon(arrow-right, white, 25);
 }
 
 .layout-overlay--expanded .layout-overlay__toggle,
 .layout-overlay--collapsed .layout-overlay__toggle {
-	float: left;
+	float: right;
 	width: 30px;
 	height: 100%;
 	background-size: 25px 25px;

--- a/components/layout-overlay/section/main.scss
+++ b/components/layout-overlay/section/main.scss
@@ -1,0 +1,23 @@
+.section-editor h3 {
+	@include nTypeAlpha(3);
+	a {
+		display: block;
+		padding: 0.5em;
+		border: 1px solid oColorsGetPaletteColor('cold-1');
+		border-width: 0 0 1px;
+	}
+}
+
+.section-editor__editor {
+	border: 1px solid oColorsGetPaletteColor('cold-1');
+	border-width: 0 0 1px;
+	padding: 0;
+
+	li {
+		list-style: none;
+	}
+}
+
+.section-editor--collapsed .section-editor__editor {
+	display: none;
+}

--- a/components/layout-overlay/section/section.js
+++ b/components/layout-overlay/section/section.js
@@ -15,9 +15,13 @@ export default class Section extends Component {
 	}
 
 	render() {
-		const cardEditors = this.props.cards.map(card => {
+		const cardEditors = this.props.cards.map((card, idx) => {
+			const previousCard = this.props.cards[Math.max(idx - 1)];
+			const previousColumn = previousCard ? previousCard.column : -1;
+			const firstOfColumn = (card.column > previousColumn);
+
 			return (<li>
-				<CardEditor card={card} />
+				<CardEditor card={card} minColumn={previousColumn} maxColumn={previousColumn + 1} showWidth={firstOfColumn} />
 			</li>)
 		})
 

--- a/components/layout-overlay/section/section.js
+++ b/components/layout-overlay/section/section.js
@@ -14,6 +14,15 @@ export default class Section extends Component {
 		this.setState({expanded: !this.state.expanded});
 	}
 
+	update(idx) {
+		return (newCard) => {
+			const newCards = this.props.cards.slice();
+			newCards[idx] = newCard;
+
+			this.props.onCardsChange(newCards);
+		};
+	}
+
 	render() {
 		const cardEditors = this.props.cards.map((card, idx) => {
 			const previousCard = this.props.cards[Math.max(idx - 1)];
@@ -21,7 +30,7 @@ export default class Section extends Component {
 			const firstOfColumn = (card.column > previousColumn);
 
 			return (<li>
-				<CardEditor card={card} minColumn={previousColumn} maxColumn={previousColumn + 1} showWidth={firstOfColumn} />
+				<CardEditor card={card} minColumn={previousColumn} maxColumn={previousColumn + 1} showWidth={firstOfColumn} onChange={this.update(idx)}/>
 			</li>)
 		})
 

--- a/components/layout-overlay/section/section.js
+++ b/components/layout-overlay/section/section.js
@@ -1,0 +1,37 @@
+import React, {Component} from 'react';
+
+import CardEditor from '../card-editor/card-editor';
+
+export default class Section extends Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {expanded: false};
+	}
+
+	toggle(e) {
+		e.preventDefault();
+		this.setState({expanded: !this.state.expanded});
+	}
+
+	render() {
+		const cardEditors = this.props.cards.map(card => {
+			return (<li>
+				<CardEditor card={card} />
+			</li>)
+		})
+
+		return (
+			<div className={'section-editor section-editor--' + (this.state.expanded ? 'expanded' : 'collapsed')}>
+				<h3>
+					<a href="" data-trackable="section-editor-toggle" onClick={this.toggle.bind(this)}>
+						{this.props.title}
+					</a>
+				</h3>
+				<ul className='section-editor__editor'>
+					{cardEditors}
+				</ul>
+			</div>
+		);
+	}
+}

--- a/components/layout-overlay/section/section.js
+++ b/components/layout-overlay/section/section.js
@@ -17,6 +17,21 @@ export default class Section extends Component {
 	update(idx) {
 		return (newCard) => {
 			const newCards = this.props.cards.slice();
+			const widthDiff = +newCards[idx].width - newCard.width;
+
+			if(newCard.width < 2) return;
+
+			// on width change, update a neihgboring column width
+			if(widthDiff !== 0) {
+				const column = +newCards[idx].column;
+				const cardToChange = newCards.find((card) => +card.column > column) || newCards.find((card) => +card.column === column - 1)
+
+				if((+cardToChange.width + widthDiff) < 2) return;
+
+				cardToChange.width = +cardToChange.width + widthDiff;
+				// bail if we're making a card too narrow
+			}
+
 			newCards[idx] = newCard;
 
 			this.props.onCardsChange(newCards);

--- a/components/layout-overlay/section/section.js
+++ b/components/layout-overlay/section/section.js
@@ -2,6 +2,23 @@ import React, {Component} from 'react';
 
 import CardEditor from '../card-editor/card-editor';
 
+// makes sure layout description is consistent
+const enforceConstraints = (cards) => {
+	return cards.map((card, idx) => {
+		if(idx < 1) return card;
+
+		// ensure monotonic columns
+		card.column = Math.max(+card.column, +cards[idx - 1].column);
+		card.column = Math.min(+card.column, +cards[idx - 1].column + 1);
+
+		// ensure constant widths in columns
+		if(+card.column === +cards[idx - 1].column)
+			card.width = +cards[idx - 1].width
+
+		return card;
+	});
+}
+
 export default class Section extends Component {
 	constructor(props) {
 		super(props);
@@ -18,7 +35,9 @@ export default class Section extends Component {
 		return (newCard) => {
 			const newCards = this.props.cards.slice();
 			const widthDiff = +newCards[idx].width - newCard.width;
+			const columnDiff = +newCard.column - newCards[idx].column;
 
+			// bail if we're making a card too narrow
 			if(newCard.width < 2) return;
 
 			// on width change, update a neihgboring column width
@@ -26,15 +45,20 @@ export default class Section extends Component {
 				const column = +newCards[idx].column;
 				const cardToChange = newCards.find((card) => +card.column > column) || newCards.find((card) => +card.column === column - 1)
 
+				// bail if we're making a card too narrow
 				if((+cardToChange.width + widthDiff) < 2) return;
 
 				cardToChange.width = +cardToChange.width + widthDiff;
-				// bail if we're making a card too narrow
+			}
+
+			// on column change, take a width of the target column
+			if(columnDiff !== 0) {
+				newCard.width = newCards[idx + columnDiff].width;
 			}
 
 			newCards[idx] = newCard;
 
-			this.props.onCardsChange(newCards);
+			this.props.onCardsChange(enforceConstraints(newCards));
 		};
 	}
 

--- a/components/layout-overlay/section/section.js
+++ b/components/layout-overlay/section/section.js
@@ -31,18 +31,18 @@ export default class Section extends Component {
 		this.setState({expanded: !this.state.expanded});
 	}
 
-	update(idx) {
+	update(cardIndex) {
 		return (newCard) => {
 			const newCards = this.props.cards.slice();
-			const widthDiff = +newCards[idx].width - newCard.width;
-			const columnDiff = +newCard.column - newCards[idx].column;
+			const widthDiff = +newCards[cardIndex].width - newCard.width;
+			const columnDiff = +newCard.column - newCards[cardIndex].column;
 
 			// bail if we're making a card too narrow
 			if(newCard.width < 2) return;
 
 			// on width change, update a neihgboring column width
 			if(widthDiff !== 0) {
-				const column = +newCards[idx].column;
+				const column = +newCards[cardIndex].column;
 				const cardToChange = newCards.find((card) => +card.column > column) || newCards.find((card) => +card.column === column - 1)
 
 				// bail if we're making a card too narrow
@@ -53,10 +53,10 @@ export default class Section extends Component {
 
 			// on column change, take a width of the target column
 			if(columnDiff !== 0) {
-				newCard.width = newCards[idx + columnDiff].width;
+				newCard.width = newCards[cardIndex + columnDiff].width;
 			}
 
-			newCards[idx] = newCard;
+			newCards[cardIndex] = newCard;
 
 			this.props.onCardsChange(enforceConstraints(newCards));
 		};

--- a/components/layout/config.js
+++ b/components/layout/config.js
@@ -1,0 +1,53 @@
+import {format as dateFormat} from 'o-date';
+import FastFt from '../fast-ft/fast-ft';
+
+const date = dateFormat(new Date(), 'EEEE MMMM yyyy');
+
+export default [
+	{
+		id: 'top-stories',
+		title: 'Top Stories',
+		style: 'top-stories',
+		date: date,
+		cards: [
+			{ column: 0, width: 5, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'desktop', related: true },
+			{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium', standFirst: 'medium', image: 'desktop'},
+			{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium' },
+			{ column: 2, width: 3, tagSize: 'medium', titleSize: 'small', image: 'desktop'},
+			{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'},
+			{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'},
+			{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'}
+		],
+		// FIXME sidebarComponent needs more thinking, maybe unifiying with card
+		// styles when we have those
+		sidebarComponent: FastFt
+	},
+	{
+		id: 'opinion',
+		title: 'Opinion',
+		style: 'opinion',
+		cards: [
+			{ column: 0, width: 3, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'always' },
+			{ column: 1, width: 3, tagSize: 'large', titleSize: 'medium', standFirst: 'medium'},
+			{ column: 1, width: 3, tagSize: 'large', titleSize: 'medium', standFirst: 'medium'},
+			{ column: 2, width: 4, ad: true },
+			{ column: 2, width: 4, tagSize: 'large', titleSize: 'medium' },
+			{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+			{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small' },
+			{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small' }
+		]
+	},
+	{
+		id: 'editors-pics',
+		title: 'Editor\'s Picks',
+		style: 'editors-pics',
+		cards: [
+			{ column: 0, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+			{ column: 1, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+			{ column: 2, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+			{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+			{ column: 4, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+			{ column: 5, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' }
+		]
+	}
+];

--- a/components/layout/config.js
+++ b/components/layout/config.js
@@ -10,7 +10,7 @@ export default [
 		style: 'top-stories',
 		date: date,
 		cards: [
-			{ column: 0, width: 5, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'desktop', related: true },
+			{ column: 0, width: 5, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'always', related: 3 },
 			{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium', standFirst: 'medium', image: 'desktop'},
 			{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium' },
 			{ column: 2, width: 3, tagSize: 'medium', titleSize: 'small', image: 'desktop'},

--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -1,10 +1,10 @@
 import React, {Component} from 'react';
-import dateFormat from 'dateformat';
+import {format as dateFormat} from 'o-date';
 
 import Section from '../section/section';
 import FastFt from '../fast-ft/fast-ft';
 
-const displayDate = dateFormat(new Date, 'dS mmmm yyyy');
+const displayDate = dateFormat(new Date(), 'EEEE MMMM yyyy');
 
 const sectionConfig = (props) => {
 	return [
@@ -15,7 +15,7 @@ const sectionConfig = (props) => {
 			date: displayDate,
 			columns: ['12 M5', '12 M4', '12 M3'],
 			cards: [
-				[{ tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'always', related: true }],
+				[{ tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'desktop', related: true }],
 				[
 					{ tagSize: 'large', titleSize: 'medium', standFirst: 'medium', image: 'desktop'},
 					{ tagSize: 'large', titleSize: 'medium' }

--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -4,7 +4,7 @@ import Section from '../section/section';
 
 const sectionContent = (content) => {
 	return [
-		{ body: content.top.leads.concat(content.top.items), sidebar: content.fastFT },
+		{ body: content.top.items, sidebar: content.fastFT },
 		{ body: content.opinion.items },
 		{ body: content.editorsPicks.items }
 	];

--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -1,70 +1,22 @@
 import React, {Component} from 'react';
-import {format as dateFormat} from 'o-date';
 
 import Section from '../section/section';
-import FastFt from '../fast-ft/fast-ft';
 
-const displayDate = dateFormat(new Date(), 'EEEE MMMM yyyy');
-
-const sectionConfig = (props) => {
+const sectionContent = (content) => {
 	return [
-		{
-			id: 'top-stories',
-			title: 'Top Stories',
-			style: 'top-stories',
-			date: displayDate,
-			cards: [
-				{ column: 0, width: 5, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'desktop', related: true },
-				{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium', standFirst: 'medium', image: 'desktop'},
-				{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium' },
-				{ column: 2, width: 3, tagSize: 'medium', titleSize: 'small', image: 'desktop'},
-				{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'},
-				{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'},
-				{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'}
-			],
-			content: props.content.top.leads.concat(props.content.top.items),
-			sidebarContent: props.content.fastFT,
-			sidebarComponent: FastFt
-		},
-		{
-			id: 'opinion',
-			title: 'Opinion',
-			style: 'opinion',
-			cards: [
-				{ column: 0, width: 3, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'always' },
-				{ column: 1, width: 3, tagSize: 'large', titleSize: 'medium', standFirst: 'medium'},
-				{ column: 1, width: 3, tagSize: 'large', titleSize: 'medium', standFirst: 'medium'},
-				{ column: 2, width: 4, ad: true },
-				{ column: 2, width: 4, tagSize: 'large', titleSize: 'medium' },
-				{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-				{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small' },
-				{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small' }
-			],
-			content: props.content.opinion.items
-		},
-		{
-			id: 'editors-pics',
-			title: 'Editor\'s Picks',
-			style: 'editors-pics',
-			cards: [
-				{ column: 0, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-				{ column: 1, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-				{ column: 2, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-				{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-				{ column: 4, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-				{ column: 5, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' }
-			],
-			content: props.content.editorsPicks.items
-		}
+		{ body: content.top.leads.concat(content.top.items), sidebar: content.fastFT },
+		{ body: content.opinion.items },
+		{ body: content.editorsPicks.items }
 	];
 }
 
 export default class Layout extends Component {
 	render() {
-		const sections = sectionConfig(this.props).map((section) => {
+		const content = sectionContent(this.props.content);
+		const sections = this.props.layout.map((section, i) => {
 			return (
 				<div id={section.id} key={section.id}>
-					<Section {...section} />
+					<Section {...section} content={content[i].body} sidebarContent={content[i].sidebar} />
 				</div>
 			);
 		});

--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -13,19 +13,14 @@ const sectionConfig = (props) => {
 			title: 'Top Stories',
 			style: 'top-stories',
 			date: displayDate,
-			columns: ['12 M5', '12 M4', '12 M3'],
 			cards: [
-				[{ tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'desktop', related: true }],
-				[
-					{ tagSize: 'large', titleSize: 'medium', standFirst: 'medium', image: 'desktop'},
-					{ tagSize: 'large', titleSize: 'medium' }
-				],
-				[
-					{ tagSize: 'medium', titleSize: 'small', image: 'desktop'},
-					{ tagSize: 'small', titleSize: 'tiny'},
-					{ tagSize: 'small', titleSize: 'tiny'},
-					{ tagSize: 'small', titleSize: 'tiny'}
-				]
+				{ column: 0, width: 5, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'desktop', related: true },
+				{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium', standFirst: 'medium', image: 'desktop'},
+				{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium' },
+				{ column: 2, width: 3, tagSize: 'medium', titleSize: 'small', image: 'desktop'},
+				{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'},
+				{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'},
+				{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'}
 			],
 			content: props.content.top.leads.concat(props.content.top.items),
 			sidebarContent: props.content.fastFT,
@@ -35,22 +30,15 @@ const sectionConfig = (props) => {
 			id: 'opinion',
 			title: 'Opinion',
 			style: 'opinion',
-			columns: ['12 M3', '12 M3', '12 M4', '12 M2'],
 			cards: [
-				[{ tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'always' }],
-				[
-					{ tagSize: 'large', titleSize: 'medium', standFirst: 'medium'},
-					{ tagSize: 'large', titleSize: 'medium', standFirst: 'medium'}
-				],
-				[
-					{ ad: true },
-					{ tagSize: 'large', titleSize: 'medium' }
-				],
-				[
-					{ tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-					{ tagSize: 'medium', titleSize: 'small' },
-					{ tagSize: 'medium', titleSize: 'small' }
-				]
+				{ column: 0, width: 3, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'always' },
+				{ column: 1, width: 3, tagSize: 'large', titleSize: 'medium', standFirst: 'medium'},
+				{ column: 1, width: 3, tagSize: 'large', titleSize: 'medium', standFirst: 'medium'},
+				{ column: 2, width: 4, ad: true },
+				{ column: 2, width: 4, tagSize: 'large', titleSize: 'medium' },
+				{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+				{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small' },
+				{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small' }
 			],
 			content: props.content.opinion.items
 		},
@@ -58,14 +46,13 @@ const sectionConfig = (props) => {
 			id: 'editors-pics',
 			title: 'Editor\'s Picks',
 			style: 'editors-pics',
-			columns: ['12 M4 L2', '12 M4 L2', '12 M4 L2', '12 M4 L2', '12 M4 L2', '12 M4 L2'],
 			cards: [
-				[{ tagSize: 'medium', titleSize: 'small', image: 'desktop' }],
-				[{ tagSize: 'medium', titleSize: 'small', image: 'desktop' }],
-				[{ tagSize: 'medium', titleSize: 'small', image: 'desktop' }],
-				[{ tagSize: 'medium', titleSize: 'small', image: 'desktop' }],
-				[{ tagSize: 'medium', titleSize: 'small', image: 'desktop' }],
-				[{ tagSize: 'medium', titleSize: 'small', image: 'desktop' }]
+				{ column: 0, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+				{ column: 1, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+				{ column: 2, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+				{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+				{ column: 4, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
+				{ column: 5, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' }
 			],
 			content: props.content.editorsPicks.items
 		}

--- a/components/layout/main.js
+++ b/components/layout/main.js
@@ -1,14 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import Layout from './Layout';
+import Layout from './layout';
+import initialLayout from './config';
 
-function init(el, content) {
+let element;
+let content;
+
+function init(el, initialContent) {
 	if (!el) return;
+	element = el;
+	content = initialContent;
 
-	ReactDOM.render(<Layout content={content} />, el);
+	render(initialLayout);
+}
+
+function render(layout) {
+	ReactDOM.render(<Layout content={content} layout={layout} />, element);
 }
 
 export default {
-	init: init
+	init: init,
+	render: render
 }

--- a/components/layout/main.js
+++ b/components/layout/main.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Layout from './Layout';
+
+function init(el, content) {
+	if (!el) return;
+
+	ReactDOM.render(<Layout content={content} />, el);
+}
+
+export default {
+	init: init
+}

--- a/components/section/section-content/section-content.js
+++ b/components/section/section-content/section-content.js
@@ -3,12 +3,12 @@ import Card from '../../card/card';
 
 const buildColumns = (cards) => {
 	return cards.reduce(([columns, currentColumn], card) => {
-		if(card.column === currentColumn) {
+		if(+card.column === currentColumn) {
 			columns[currentColumn].push(card);
 			return [columns, currentColumn];
 		} else {
 			columns.push([card]);
-			return [columns, card.column]
+			return [columns, +card.column]
 		}
 	}, [ [[]], 0 ])[0];
 }

--- a/components/section/section-content/section-content.js
+++ b/components/section/section-content/section-content.js
@@ -22,6 +22,8 @@ export default class SectionContent extends Component {
 			const cards = columnCards.map(card => {
 				const article = articles.shift();
 
+				if(!article) return null;
+
 				const props = Object.assign({}, card, { article, key: article.id });
 				return <Card {...props} />;
 			});

--- a/components/section/section-content/section-content.js
+++ b/components/section/section-content/section-content.js
@@ -1,12 +1,25 @@
 import React, {Component} from 'react';
 import Card from '../../card/card';
 
+const buildColumns = (cards) => {
+	return cards.reduce(([columns, currentColumn], card) => {
+		if(card.column === currentColumn) {
+			columns[currentColumn].push(card);
+			return [columns, currentColumn];
+		} else {
+			columns.push([card]);
+			return [columns, card.column]
+		}
+	}, [ [[]], 0 ])[0];
+}
+
 export default class SectionContent extends Component {
 	render() {
 		const articles = this.props.articles.slice();
 
-		const columns = this.props.columns.map((column, colId) => {
-			const cards = this.props.cards[colId].map(card => {
+		const columns = buildColumns(this.props.cards).map((columnCards, colIdx) => {
+			const columnWidth = columnCards[0].width;
+			const cards = columnCards.map(card => {
 				const article = articles.shift();
 
 				const props = Object.assign({}, card, { article, key: article.id });
@@ -14,7 +27,7 @@ export default class SectionContent extends Component {
 			});
 
 			return (
-				<div className={'column ' + this.props.style + '__column'} data-o-grid-colspan={column} key={colId}>
+				<div className={'column ' + this.props.style + '__column'} data-o-grid-colspan={'12 M' + columnWidth} key={colIdx}>
 					{cards}
 				</div>
 			);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "babel": "^5.6.14",
     "body-parser": "^1.13.2",
-    "dateformat": "^1.0.11",
     "forever": "^0.14.2",
     "ft-next-express": "^15.1.0",
     "o-date": "https://github.com/Financial-Times/o-date/archive/1.1.1.tar.gz",

--- a/server/config/queries.js
+++ b/server/config/queries.js
@@ -141,6 +141,57 @@ const frontPage = (region) => (`
 	}
 `);
 
+const newFrontPage = (region) => (`
+	${fragments}
+
+	query FrontPage {
+		popularTopics {
+			name
+			url
+		}
+		top(region: ${region}) {
+			items(type: Article) {
+				... Basic
+				... Extended
+				... Related
+			}
+			liveBlogs: items(type: LiveBlog) {
+				... Basic
+				... Extended
+				... on LiveBlog {
+					status
+					updates(limit: 1) {
+						date
+						text
+					}
+				}
+			}
+		}
+		fastFT {
+			items {
+				... Basic
+			}
+		}
+		editorsPicks {
+			title
+			items(limit: 6) {
+				... Basic
+				... ExtendedSmallImage
+				... Related
+			}
+		}
+		opinion {
+			url
+			items {
+				... Basic
+				... Extended
+				... Related
+			}
+		}
+	}
+`);
+
+
 // fastFT query
 const fastFT = `
 	query FastFT {
@@ -156,5 +207,6 @@ const fastFT = `
 
 export default {
 	frontPage,
+	newFrontPage,
 	fastFT
 };

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -5,6 +5,7 @@ import { logger } from 'ft-next-express';
 import FastFtFeed from '../../components/fastft/fastftfeed';
 import Feed from '../../components/feed/feed';
 import Layout from '../../components/layout/layout';
+import initialLayout from '../../components/layout/config';
 
 export default (region) => {
 	return (req, res, next) => {
@@ -22,6 +23,7 @@ export default (region) => {
 						Feed,
 						Layout,
 						content: data,
+						initialLayout,
 						region
 					}
 				);

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -1,4 +1,4 @@
-import { frontPage as frontPageQuery } from '../config/queries';
+import queries from '../config/queries';
 import getData from '../libs/get-data';
 import { logger } from 'ft-next-express';
 
@@ -9,12 +9,14 @@ import initialLayout from '../../components/layout/config';
 
 export default (region) => {
 	return (req, res, next) => {
+		const query = (res.locals.flags.frontPageLayoutPrototype ? queries.newFrontPage(region) : queries.frontPage(region));
+
 		res.set({
 			// needs to be private so we can vary for signed in state, ab tests, etc
 			'Surrogate-Control': 'max-age=60,stale-while-revalidate=6,stale-if-error=259200'
 		});
 
-		getData(frontPageQuery(region), res.locals.flags)
+		getData(query, res.locals.flags)
 			.then(data => {
 				res.render('front-page',
 					{

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -1,6 +1,6 @@
 {{#if @root.flags.frontPageLayoutPrototype}}
 	<div id="layout-overlay-container"></div>
-	<section id="main-body" data-main-content="{{json content}}">{{{ reactRenderToString Layout content=content }}}</section>
+	<section id="main-body" data-main-content="{{json content}}">{{{ reactRenderToString Layout content=content layout=initialLayout }}}</section>
 {{else}}
 	{{#defineBlock 'head'}}
 		<meta name="dfp_site" content="home" />

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -1,4 +1,5 @@
 {{#if @root.flags.frontPageLayoutPrototype}}
+	<div id="layout-overlay-container"></div>
 	<section id="main-body" data-main-content="{{json content}}">{{{ reactRenderToString Layout content=content }}}</section>
 {{else}}
 	{{#defineBlock 'head'}}

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -1,5 +1,5 @@
 {{#if @root.flags.frontPageLayoutPrototype}}
-	{{{ reactRenderToString Layout content=content }}}
+	<section id="main-body" data-main-content="{{json content}}">{{{ reactRenderToString Layout content=content }}}</section>
 {{else}}
 	{{#defineBlock 'head'}}
 		<meta name="dfp_site" content="home" />

--- a/webpack.config.hot.js
+++ b/webpack.config.hot.js
@@ -25,7 +25,7 @@ const config = {
 	output: {
 		path: path.join(__dirname, 'public'),
 		filename: 'main.js',
-		publicPath: '/front-page/'
+		publicPath: 'http://localhost:8888/front-page/'
 	},
 	plugins: plugins,
 	module: {


### PR DESCRIPTION
This will add UI to exercise the various tools the grid layout engine supports live in the browser to demonstrate the flexibility of the layout system and make it easier for people to understand the various degrees of freedom we have in the design. 

Eventually, when the simpler weight based layout engine is built, this will get updated to control the story weights instead (and also randomise them to a degree to get different layout templates).

# To Do

- [x] client-side rendering
- [x] make sure hot loading works
- [x] layout controls overlay
- [x] card options controls
- [x] enforce column and width constraints when changing values
- [x] fetch related stories for everything
- [x] change all taxon colours to claret