### PR TITLE
Layout prototype constraints

### DIFF
--- a/components/card/card.js
+++ b/components/card/card.js
@@ -8,14 +8,10 @@ import Related from './related/related';
 
 import Ad from './ad';
 
-const className = (classes) => {
-	let result = []
+const className = (size) => {
+	const result = ['card', (size === 'tiny' ? 'card--inline' : null)];
 
-	for(const name in classes) {
-		if(classes[name]) result.push(name)
-	}
-
-	return result.join(' ');
+	return result.filter(it => !!it).join(' ');
 }
 
 const tagSize = (size) => {
@@ -59,7 +55,7 @@ class Card extends Component {
 		if(this.props.ad) return <Ad />;
 
 		return (
-			<article className={className({card: true, 'card--inline': (size === 'tiny')})} data-trackable="card">
+			<article className={className(size)} data-trackable="card">
 				<Tag tag={article.primaryTag} size={tagSize(size)} />
 				<Title title={article.title} href={'/content/' + article.id} size={titleSize(size, this.props.order, showImage)} />
 				{standFirst ? <Standfirst article={article} style={article.primaryTag.taxonomy} size={standFirstSize(size)} /> : null}

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -29,8 +29,8 @@ const tagSize = (size) => {
 	return sizes[size];
 }
 
-const titleSize = (size, column, showImage) => {
-	if(size === 'large' && +column === 0 && !showImage)
+const titleSize = (size, order, showImage) => {
+	if(size === 'large' && +order === 0 && !showImage)
 		return 'huge';
 
 	return size;
@@ -61,7 +61,7 @@ class Card extends Component {
 		return (
 			<article className={className({card: true, 'card--inline': (size === 'tiny')})} data-trackable="card">
 				<Tag tag={article.primaryTag} size={tagSize(size)} />
-				<Title title={article.title} href={'/content/' + article.id} size={titleSize(size, this.props.column, showImage)} />
+				<Title title={article.title} href={'/content/' + article.id} size={titleSize(size, this.props.order, showImage)} />
 				{standFirst ? <Standfirst article={article} style={article.primaryTag.taxonomy} size={standFirstSize(size)} /> : null}
 				{showImage ? <Image article={article} display={image} /> : null}
 				{related ? <Related articles={article.relatedContent} limit={this.props.related} /> : null}

--- a/components/card/card.js
+++ b/components/card/card.js
@@ -18,13 +18,40 @@ const className = (classes) => {
 	return result.join(' ');
 }
 
+const tagSize = (size) => {
+	const sizes = {
+		large: 'large',
+		medium: 'large',
+		small: 'medium',
+		tiny: 'small'
+	}
+
+	return sizes[size];
+}
+
+const titleSize = (size, column, showImage) => {
+	if(size === 'large' && +column === 0 && !showImage)
+		return 'huge';
+
+	return size;
+}
+
+const standFirstSize = (size) => {
+	const sizes = {
+		large: 'large',
+		medium: 'medium',
+		small: 'medium'
+	}
+
+	return sizes[size];
+}
+
 class Card extends Component {
 	render() {
 		const article = this.props.article;
 
-		const tagSize = this.props.tagSize;
-		const titleSize = this.props.titleSize;
-		const standFirst = this.props.standFirst;
+		const size = this.props.size;
+		const standFirst = size === 'large' || size === 'medium' && !!this.props.standFirst;
 		const image = this.props.image;
 		const showImage = !!image && article.primaryImage;
 		const related = !!this.props.related && article.relatedContent && article.relatedContent.length > 0;
@@ -32,10 +59,10 @@ class Card extends Component {
 		if(this.props.ad) return <Ad />;
 
 		return (
-			<article className={className({card: true, 'card--inline': (titleSize === 'tiny')})} data-trackable="card">
-				<Tag tag={article.primaryTag} size={tagSize}/>
-				<Title title={article.title} href={'/content/' + article.id} size={titleSize} />
-				{standFirst ? <Standfirst article={article} style={article.primaryTag.taxonomy} size={standFirst} /> : null}
+			<article className={className({card: true, 'card--inline': (size === 'tiny')})} data-trackable="card">
+				<Tag tag={article.primaryTag} size={tagSize(size)} />
+				<Title title={article.title} href={'/content/' + article.id} size={titleSize(size, this.props.column, showImage)} />
+				{standFirst ? <Standfirst article={article} style={article.primaryTag.taxonomy} size={standFirstSize(size)} /> : null}
 				{showImage ? <Image article={article} display={image} /> : null}
 				{related ? <Related articles={article.relatedContent} limit={this.props.related} /> : null}
 			</article>

--- a/components/card/main.scss
+++ b/components/card/main.scss
@@ -8,6 +8,8 @@
 	width: 100%;
 	background-color: getColor('pink');
 	margin-top: oGridGutter();
+	border: 1px solid getColor('warm-3');
+	border-width: 0 0 1px;
 	padding: 10px;
 	display: flex;
 	flex-direction: column;
@@ -31,8 +33,11 @@
 	&:last-child {
 		flex: 2;
 	}
-}
 
+	.section--opinion & {
+		border-width: 0 0 0 1px;
+	}
+}
 
 .card--ad {
 	padding-left: 0;

--- a/components/card/related/main.scss
+++ b/components/card/related/main.scss
@@ -1,5 +1,6 @@
 .card__related-items {
 	padding: 0;
+	margin-top: 0.4em;
 	list-style-type: none;
 }
 .card__related-item {

--- a/components/card/standfirst/main.scss
+++ b/components/card/standfirst/main.scss
@@ -2,6 +2,7 @@
 	font-family: $n-type-sans-serif;
 	font-weight: oFontsWeight(light);
 	margin-top: 5px;
+	margin-bottom: 0.3em;
 }
 .card__standfirst--authors {
 	font-family: $n-type-serif;

--- a/components/card/title/main.scss
+++ b/components/card/title/main.scss
@@ -10,6 +10,10 @@
 	font-weight: oFontsWeight(regular);
 	margin-top: 5px;
 }
+.card__title--huge {
+	font-size: 30px;
+	line-height: 34px;
+}
 .card__title--large {
 	font-size: 24px;
 	line-height: 28px;

--- a/components/layout-overlay/card-editor/card-editor.js
+++ b/components/layout-overlay/card-editor/card-editor.js
@@ -28,7 +28,13 @@ export default class CardEditor extends Component {
 						onChange={this.change('column')} />
 					{ this.props.showWidth ? <label>Width</label> : null }
 					{ this.props.showWidth ?
-						<input type="number" data-trackable="card-width" value={this.props.card.width || 2} onChange={this.change('width')} />
+						<input
+							type="number"
+							data-trackable="card-width"
+							value={this.props.card.width || 2}
+							min="2"
+							max={this.props.card.column > 0 ? 4 : 6}
+							onChange={this.change('width')} />
 						: null }
 				</p>
 				<p>

--- a/components/layout-overlay/card-editor/card-editor.js
+++ b/components/layout-overlay/card-editor/card-editor.js
@@ -8,7 +8,7 @@ export default class CardEditor extends Component {
 			if(newValue === 'none')
 				delete newCard[key];
 			else
-				newCard[key] = newValue;
+				newCard[key] = (newValue === 'yes' ? true : newValue);
 
 			this.props.onChange(newCard);
 		};
@@ -32,30 +32,22 @@ export default class CardEditor extends Component {
 						: null }
 				</p>
 				<p>
-					<label>Tag size</label>
-					<select data-trackable="card-tag-size" value={this.props.card.tagSize} onChange={this.change('tagSize')}>
-						<option value="large">Large</option>
-						<option value="medium">Medium</option>
-						<option value="small">Small</option>
-					</select>
-				</p>
-				<p>
-					<label>Title size</label>
-					<select data-trackable="card-title-size" value={this.props.card.titleSize} onChange={this.change('titleSize')}>
+					<label>Text size</label>
+					<select data-trackable="card-text-size" value={this.props.card.size} onChange={this.change('size')}>
 						<option value="large">Large</option>
 						<option value="medium">Medium</option>
 						<option value="small">Small</option>
 						<option value="tiny">Tiny</option>
 					</select>
 				</p>
+				{ this.props.card.size === 'medium' ?
 				<p>
 					<label>Stand first</label>
 					<select data-trackable="card-stand-first" value={this.props.card.standFirst || 'none'} onChange={this.change('standFirst')}>
-						<option value="large">Large</option>
-						<option value="medium">Medium</option>
+						<option value="yes">Shown</option>
 						<option value="none">Hidden</option>
 					</select>
-				</p>
+				</p> : null }
 				<p>
 					<label>Image</label>
 					<select data-trackable="card-image" value={this.props.card.image || 'none'} onChange={this.change('image')}>

--- a/components/layout-overlay/section/section.js
+++ b/components/layout-overlay/section/section.js
@@ -40,6 +40,9 @@ export default class Section extends Component {
 			// bail if we're making a card too narrow
 			if(newCard.width < 2) return;
 
+			// The width and column change contraints are temporary, the layout enging will dictate
+			// this and we won't need to deal with it in the end.
+
 			// on width change, update a neihgboring column width
 			if(widthDiff !== 0) {
 				const column = +newCards[cardIndex].column;

--- a/components/layout/config.js
+++ b/components/layout/config.js
@@ -10,13 +10,13 @@ export default [
 		style: 'top-stories',
 		date: date,
 		cards: [
-			{ column: 0, width: 5, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'always', related: 3 },
-			{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium', standFirst: 'medium', image: 'desktop'},
-			{ column: 1, width: 4, tagSize: 'large', titleSize: 'medium' },
-			{ column: 2, width: 3, tagSize: 'medium', titleSize: 'small', image: 'desktop'},
-			{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'},
-			{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'},
-			{ column: 2, width: 3, tagSize: 'small', titleSize: 'tiny'}
+			{ column: 0, width: 5, size: 'large', standFirst: true, image: 'always', related: 3 },
+			{ column: 1, width: 4, size: 'medium', standFirst: true, image: 'desktop'},
+			{ column: 1, width: 4, size: 'medium' },
+			{ column: 2, width: 3, size: 'small', image: 'desktop'},
+			{ column: 2, width: 3, size: 'tiny' },
+			{ column: 2, width: 3, size: 'tiny' },
+			{ column: 2, width: 3, size: 'tiny' }
 		],
 		// FIXME sidebarComponent needs more thinking, maybe unifiying with card
 		// styles when we have those
@@ -27,27 +27,27 @@ export default [
 		title: 'Opinion',
 		style: 'opinion',
 		cards: [
-			{ column: 0, width: 3, tagSize: 'large', titleSize: 'large', standFirst: 'large', image: 'always' },
-			{ column: 1, width: 3, tagSize: 'large', titleSize: 'medium', standFirst: 'medium'},
-			{ column: 1, width: 3, tagSize: 'large', titleSize: 'medium', standFirst: 'medium'},
+			{ column: 0, width: 3, size: 'large', standFirst: true, image: 'always' },
+			{ column: 1, width: 3, size: 'medium', standFirst: true },
+			{ column: 1, width: 3, size: 'medium', standFirst: true },
 			{ column: 2, width: 4, ad: true },
-			{ column: 2, width: 4, tagSize: 'large', titleSize: 'medium' },
-			{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-			{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small' },
-			{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small' }
+			{ column: 2, width: 4, size: 'medium' },
+			{ column: 3, width: 2, size: 'small', image: 'desktop' },
+			{ column: 3, width: 2, size: 'small' },
+			{ column: 3, width: 2, size: 'small' }
 		]
 	},
 	{
 		id: 'editors-pics',
 		title: 'Editor\'s Picks',
-		style: 'editors-pics',
+		style: 'editors-picks',
 		cards: [
-			{ column: 0, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-			{ column: 1, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-			{ column: 2, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-			{ column: 3, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-			{ column: 4, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' },
-			{ column: 5, width: 2, tagSize: 'medium', titleSize: 'small', image: 'desktop' }
+			{ column: 0, width: 2, size: 'small', image: 'desktop' },
+			{ column: 1, width: 2, size: 'small', image: 'desktop' },
+			{ column: 2, width: 2, size: 'small', image: 'desktop' },
+			{ column: 3, width: 2, size: 'small', image: 'desktop' },
+			{ column: 4, width: 2, size: 'small', image: 'desktop' },
+			{ column: 5, width: 2, size: 'small', image: 'desktop' }
 		]
 	}
 ];

--- a/components/layout/config.js
+++ b/components/layout/config.js
@@ -30,11 +30,11 @@ export default [
 			{ column: 0, width: 3, size: 'large', standFirst: true, image: 'always' },
 			{ column: 1, width: 3, size: 'medium', standFirst: true },
 			{ column: 1, width: 3, size: 'medium', standFirst: true },
-			{ column: 2, width: 4, ad: true },
-			{ column: 2, width: 4, size: 'medium' },
-			{ column: 3, width: 2, size: 'small', image: 'desktop' },
-			{ column: 3, width: 2, size: 'small' },
-			{ column: 3, width: 2, size: 'small' }
+			{ column: 2, width: 2, size: 'small', image: 'desktop' },
+			{ column: 2, width: 2, size: 'small' },
+			{ column: 2, width: 2, size: 'small' },
+			{ column: 3, width: 4, size: 'small' },
+			{ column: 3, width: 4, ad: true }
 		]
 	},
 	{

--- a/components/section/section-content/section-content.js
+++ b/components/section/section-content/section-content.js
@@ -4,7 +4,7 @@ import Card from '../../card/card';
 const buildColumns = (cards) => {
 	return cards.reduce(([columns, currentColumn], card, cardIndex) => {
 		card.order = cardIndex;
-		
+
 		if(+card.column === currentColumn) {
 			columns[currentColumn].push(card);
 			return [columns, currentColumn];
@@ -38,7 +38,7 @@ export default class SectionContent extends Component {
 		});
 
 		return (
-			<div className="top-stories o-grid-container o-grid-container--compact">
+			<div className="o-grid-container o-grid-container--compact">
 				<div className="o-grid-row">
 					{columns}
 				</div>

--- a/components/section/section-content/section-content.js
+++ b/components/section/section-content/section-content.js
@@ -2,7 +2,9 @@ import React, {Component} from 'react';
 import Card from '../../card/card';
 
 const buildColumns = (cards) => {
-	return cards.reduce(([columns, currentColumn], card) => {
+	return cards.reduce(([columns, currentColumn], card, cardIndex) => {
+		card.order = cardIndex;
+		
 		if(+card.column === currentColumn) {
 			columns[currentColumn].push(card);
 			return [columns, currentColumn];

--- a/components/section/section.js
+++ b/components/section/section.js
@@ -11,7 +11,7 @@ export default class Section extends Component {
 		const columns = columnConfig(!!this.props.sidebarContent);
 
 		return (
-			<section className="section o-grid-container">
+			<section className={'section o-grid-container section--' + this.props.style}>
 				<div className="o-grid-row">
 					<div data-o-grid-colspan={columns[0]} className="section__column">
 						<SectionMeta title={this.props.title} date={this.props.date} />


### PR DESCRIPTION
This limits the options in the layout UI slightly to only sane combinations based on @clmntnbrn's input. Also adding a bit of styling to make it look prettier.

- [x] New title size for the lead card without an image
- [x] Tag, title and stand first size governed by a single font size
- [x] Width 5 and 6 only allowed in the first column
- [x] card borders to aid visually distinguishing sections