### PR TITLE
FastFT item & time display order

### DIFF
--- a/components/fast-ft/fast-ft-item.js
+++ b/components/fast-ft/fast-ft-item.js
@@ -4,7 +4,7 @@ import {format as dateFormat} from 'o-date';
 class FastFtItem extends Component {
 	render() {
 		const article = this.props.article;
-		const time = dateFormat(article.lastPublished, 'H:mm a');
+		const time = dateFormat(article.lastPublished, 'H:mm');
 		return (
 			<div className="fast-ft__item">
 				<h2 className="fast-ft__item__title">

--- a/components/fast-ft/fast-ft-item.js
+++ b/components/fast-ft/fast-ft-item.js
@@ -7,9 +7,10 @@ class FastFtItem extends Component {
 		const time = dateFormat(article.lastPublished, 'H:mm a');
 		return (
 			<div className="fast-ft__item">
-				<time className="fast-ft__time" datetime={article.lastPublished}>{time}</time>
 				<h2 className="fast-ft__item__title">
 					<a className="fast-ft__item__title-link" href={'/content/' + article.id} data-trackable="link">{article.title}</a>
+					<span> – </span>
+					<time className="fast-ft__time" datetime={article.lastPublished}>{time}</time>
 				</h2>
 			</div>
 		);

--- a/components/fast-ft/main.scss
+++ b/components/fast-ft/main.scss
@@ -6,6 +6,7 @@
 .fast-ft {
 	background-color: getColor('pink');
 	padding: 10px;
+	border-left: 1px solid $next-pink-dark;
 }
 .fast-ft__logo {
 	text-indent: -9999px;

--- a/components/fast-ft/main.scss
+++ b/components/fast-ft/main.scss
@@ -6,7 +6,7 @@
 .fast-ft {
 	background-color: getColor('pink');
 	padding: 10px;
-	border-left: 1px solid $next-pink-dark;
+	border-left: 1px solid getColor('warm-3');
 }
 .fast-ft__logo {
 	text-indent: -9999px;

--- a/components/fast-ft/main.scss
+++ b/components/fast-ft/main.scss
@@ -25,9 +25,7 @@
 	list-style: none;
 }
 .fast-ft__item {
-	position: relative;
 	margin-top: 10px;
-	padding-left: 55px;
 
 	*:first-child > & {
 		margin-top: 0;
@@ -35,9 +33,6 @@
 }
 .fast-ft__time {
 	@include nTypeAlpha(4);
-	position: absolute;
-	top: 0;
-	left: 0;
 	color: getColor('claret');
 }
 .fast-ft__item__title {


### PR DESCRIPTION
Changes to prototype FastFT

- [x] Styling: order of content changed to item text then time
- [x] Styling: 1px left border (like Opinion cards)
- [x] Check timestamps are local
- [x] Amend time to 24 or 12 hour clock, as required (changed to 24 hour clock)

@clmntnbrn 