### PR TITLE
Amend: Subheads markup from h2 to p

### DIFF
--- a/views/partials/carousel-card.html
+++ b/views/partials/carousel-card.html
@@ -11,11 +11,11 @@
 			</a>
 		{{/if}}
 		<div class="carousel-card__content">
-			<h2 class="story-card__taxon">
+			<p class="story-card__taxon">
 				<a href="{{primaryTag.url}}" data-trackable="primary-tag" class="story-card__link" tabindex="0" aria-label="Topic: {{primaryTag.name}}">
 					{{primaryTag.name}}
 				</a>
-			</h2>
+			</p>
 			<h1 id="{{id}}-title" class="story-card__title">
 				<a href="/content/{{id}}" data-trackable="main-link" class="carousel-card--link" tabindex="0" aria-label="{{title}}">
 					{{title}}

--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -26,11 +26,11 @@
 				</h1>
 				{{#if updates}}
 					{{#slice updates limit=1}}
-						<h2 class="story-card__summary" data-trackable="summary">{{trim text sentences=1}}</h2>
+						<p class="story-card__summary" data-trackable="summary">{{trim text sentences=1}}</p>
 					{{/slice}}
 				{{else}}
 					{{#if showSummary}}
-						<h2 class="story-card__summary" data-trackable="summary">{{{summary}}}</h2>
+						<p class="story-card__summary" data-trackable="summary">{{{summary}}}</p>
 					{{/if}}
 				{{/if}}
 			</div>


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/next-front-page/issues/265

Link in issue was broken so referenced this: http://www.w3.org/TR/html5/common-idioms.html#sub-head