### PR TITLE
Switch current home page to n-image

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "n-video": "^2.8.2",
     "n-message-prompts": "Financial-Times/n-message-prompts#^v1.0.0",
     "n-layout": "^2.0.0",
-    "n-image": "~1.3.1"
+    "n-image": "^1.3.1"
   },
   "resolutions": {
     "o-ft-icons": "next",

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
     "o-date": "^2.0.0",
     "n-video": "^2.8.2",
     "n-message-prompts": "Financial-Times/n-message-prompts#^v1.0.0",
-    "n-layout": "^2.0.0"
+    "n-layout": "^2.0.0",
+    "n-image": "~1.3.1"
   },
   "resolutions": {
     "o-ft-icons": "next",

--- a/client/components/carousel-card/main.scss
+++ b/client/components/carousel-card/main.scss
@@ -22,6 +22,10 @@
 .carousel-card__image {
 	width: 100%;
 	margin-bottom: 10px;
+
+	img {
+		width: 100%;
+	}
 }
 
 .carousel-card--link {

--- a/client/components/story-card/main.scss
+++ b/client/components/story-card/main.scss
@@ -27,6 +27,10 @@
 .story-card__image {
 	display: block;
 	width: 100%;
+
+	img {
+		width: 100%;
+	}
 }
 
 .story-card__content-inner {

--- a/server/config/queries.js
+++ b/server/config/queries.js
@@ -17,7 +17,7 @@ const fragments = `
 			name
 		}
 		primaryImage {
-			src(width: 710)
+			rawSrc
 			alt
 		}
 	}
@@ -32,7 +32,7 @@ const fragments = `
 			name
 		}
 		primaryImage {
-			src(width: 320)
+			rawSrc
 			alt
 		}
 	}

--- a/server/init.js
+++ b/server/init.js
@@ -7,6 +7,14 @@ import bodyParser from 'body-parser';
 import frontPage from './routes/front-page';
 import fastft from './routes/fastft';
 
+const srcsets = {
+	lead: { default: 470, s: 720, m: 630, l: 590, xl: 700 },
+	editors: { default: 240, s: 350, m: 350, l: 240, xl: 240 },
+	top: { default: 370, s: 240, m: 320, l: 250, xl: 350 },
+	opinion: { default: 320, s: 200, m: 200, l: 200, xl: 200 },
+	normal: { default: 470, s: 150, m: 200, l: 200, xl: 250 }
+};
+
 const app = express({
 	helpers: {
 		lowercase: (it) => it && it.toLowerCase(),
@@ -22,9 +30,7 @@ const app = express({
 					url: options.hash.img.rawSrc,
 					alt: options.hash.img.alt,
 					class: options.hash.class,
-					srcset: {
-						default: 150
-					}
+					srcset: (srcsets[options.hash.sizing] || srcsets['normal'])
 				}
 			}
 

--- a/server/init.js
+++ b/server/init.js
@@ -15,6 +15,20 @@ const app = express({
 		},
 		reactRenderToString: (klass, props) => {
 			return ReactServer.renderToString(React.createElement(klass, props.hash));
+		},
+		responsiveImage: function (options) {
+			const opts = {
+				image: {
+					url: options.hash.img.rawSrc,
+					alt: options.hash.img.alt,
+					class: options.hash.class,
+					srcset: {
+						default: 150
+					}
+				}
+			}
+
+			return options.fn(Object.assign({}, this, opts));
 		}
 	}
 });

--- a/views/partials/carousel-card.html
+++ b/views/partials/carousel-card.html
@@ -2,12 +2,9 @@
 	<div class="carousel-card--inner o-grid-row">
 		{{#if primaryImage}}
 			<a href="/content/{{id}}" class="carousel-card__image-link" role="presentation" aria-hidden="true" data-trackable="image-link">
-				{{#with primaryImage}}
-					<img class='carousel-card__image'
-						src="{{src}}"
-						alt=""
-					/>
-				{{/with}}
+				{{#responsiveImage img=primaryImage class="carousel-card__image"}}
+					{{> n-image/templates/image}}
+				{{/responsiveImage}}
 			</a>
 		{{/if}}
 		<div class="carousel-card__content">

--- a/views/partials/carousel-card.html
+++ b/views/partials/carousel-card.html
@@ -2,7 +2,7 @@
 	<div class="carousel-card--inner o-grid-row">
 		{{#if primaryImage}}
 			<a href="/content/{{id}}" class="carousel-card__image-link" role="presentation" aria-hidden="true" data-trackable="image-link">
-				{{#responsiveImage img=primaryImage class="carousel-card__image"}}
+				{{#responsiveImage img=primaryImage sizing="editors" class="carousel-card__image"}}
 					{{> n-image/templates/image}}
 				{{/responsiveImage}}
 			</a>

--- a/views/partials/lead-today.html
+++ b/views/partials/lead-today.html
@@ -13,7 +13,7 @@
 		<div class="article-group o-grid-row" role="presentation">
 			{{#slice leads limit=1}}
 				<div class="article no-ff-padding" data-o-grid-colspan="12">
-					{{> story-card related=true showSummary=true }}
+					{{> story-card related=true showSummary=true imageSizing="lead" }}
 				</div>
 			{{/slice}}
 		</div>
@@ -21,7 +21,7 @@
 			{{#if liveBlogs}}
 				{{#each liveBlogs}}
 					<div class="liveblog" data-o-grid-colspan="12">
-						{{> story-card live=live}}
+						{{> story-card live=live imageSizing="top"}}
 					</div>
 				{{/each}}
 			{{/if}}
@@ -29,14 +29,14 @@
 		<div class="article-group o-grid-row" role="presentation">
 			{{#slice items limit=3}}
 				<div class="article" data-o-grid-colspan="12 M4">
-					{{> story-card }}
+					{{> story-card imageSizing="top"}}
 				</div>
 			{{/slice}}
 		</div>
 		<div class="article-group o-grid-row" role="presentation">
 			{{#slice items limit=3 offset=3}}
 				<div class="article" data-o-grid-colspan="12 M4">
-					{{> story-card }}
+					{{> story-card imageSizing="top"}}
 				</div>
 			{{/slice}}
 		</div>
@@ -44,7 +44,7 @@
 			<div class="article-group o-grid-row" role="presentation">
 				{{#slice items limit=3 offset=6}}
 					<div class="article" data-o-grid-colspan="12 M4">
-						{{> story-card }}
+						{{> story-card imageSizing="top"}}
 					</div>
 				{{/slice}}
 			</div>

--- a/views/partials/opinion.html
+++ b/views/partials/opinion.html
@@ -11,21 +11,21 @@
 			<div class="article-group o-grid-row">
 				{{#slice items limit=2}}
 					<div class="article">
-						{{> story-card }}
+						{{> story-card imageSizing="opinion" }}
 					</div>
 				{{/slice}}
 			</div>
 			<div class="article-group o-grid-row">
 				{{#slice items limit=3 offset=2}}
 					<div class="article">
-						{{> story-card }}
+						{{> story-card imageSizing="opinion" }}
 					</div>
 				{{/slice}}
 			</div>
 			<div class="article-group o-grid-row">
 				{{#slice items limit=2 offset=5}}
 					<div class="article">
-						{{> story-card }}
+						{{> story-card imageSizing="opinion" }}
 					</div>
 				{{/slice}}
 			</div>

--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -2,7 +2,7 @@
 	<div class="story-card--inner o-grid-row">
 		{{#if primaryImage}}
 			<a href="/content/{{id}}" class="story-card__image-link" data-trackable="image" role="presentation" aria-hidden="true">
-				{{#responsiveImage img=primaryImage class="story-card__image"}}
+				{{#responsiveImage img=primaryImage sizing=imageSizing class="story-card__image"}}
 					{{> n-image/templates/image}}
 				{{/responsiveImage}}
 			</a>

--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -2,11 +2,9 @@
 	<div class="story-card--inner o-grid-row">
 		{{#if primaryImage}}
 			<a href="/content/{{id}}" class="story-card__image-link" data-trackable="image" role="presentation" aria-hidden="true">
-				{{#with primaryImage}}
-					<img class='story-card__image'
-					src="{{src}}" alt=""
-					/>
-				{{/with}}
+				{{#responsiveImage img=primaryImage class="story-card__image"}}
+					{{> n-image/templates/image}}
+				{{/responsiveImage}}
 			</a>
 		{{/if}}
 		<div class="story-card__content">


### PR DESCRIPTION
To improve page load time on small screens and also hopefully get better ordering of asset loading (icons and fonts first, images second).

Fix #131

# To do

- [x] switch to n-image
- [x] define breakpoint sizes
- [x] make the sizes fit the image cases (lead, top stories story, editor's pick, others)