### PR TITLE
Add timeout to graphQL fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node-sass": "^3.2.0",
     "nodemon": "^1.3.2",
     "notify-saucelabs": "^1.0.1",
-    "origami-build-tools": "Financial-Times/origami-build-tools#fix-stream-combiner2-attempt2",
+    "origami-build-tools": "^4.1.1",
     "pre-git": "^0.6.2",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.0",

--- a/server/libs/get-data.js
+++ b/server/libs/get-data.js
@@ -11,7 +11,8 @@ const getData = (query, flags) => {
 			headers: {
 				'Content-Type': 'application/json',
 				'X-Flags': xFlagsHeader
-			}
+			},
+			timeout: 3000
 		})
 		.then(response => {
 			if (response.ok) {


### PR DESCRIPTION
Should prevent front page response times ballooning if graphQL has problems