### PR TITLE
Increase timeout to 4000

### DIFF
--- a/server/libs/get-data.js
+++ b/server/libs/get-data.js
@@ -12,7 +12,7 @@ const getData = (query, flags = {}) => {
 				'Content-Type': 'application/json',
 				'X-Flags': xFlagsHeader
 			},
-			timeout: 3000
+			timeout: 4000
 		})
 		.then(response => {
 			if (response.ok) {


### PR DESCRIPTION
/cc @charypar @matthew-andrews @ironsidevsquincy 
The max response time for graphql sometimes pops between 3000-3500ms. This should only really be a temporary placation, until we do the polling of graphQL.