### PR TITLE
Get (most) tracking for prototype in sync with old page

### DIFF
--- a/components/card/title/title.js
+++ b/components/card/title/title.js
@@ -5,7 +5,7 @@ export default class Title extends Component {
 	render () {
 		return (
 			<h2 className={'card__title ' + responsiveClass('card__title', this.props.size)}>
-				<a className="card__title-link" href={this.props.href} data-trackable="link">{this.props.title}</a>
+				<a className="card__title-link" href={this.props.href} data-trackable="main-link">{this.props.title}</a>
 			</h2>
 		);
 	}

--- a/components/fast-ft/fast-ft-item.js
+++ b/components/fast-ft/fast-ft-item.js
@@ -8,7 +8,7 @@ class FastFtItem extends Component {
 		return (
 			<div className="fast-ft__item">
 				<h2 className="fast-ft__item__title">
-					<a className="fast-ft__item__title-link" href={'/content/' + article.id} data-trackable="link">{article.title}</a>
+					<a className="fast-ft__item__title-link" href={'/content/' + article.id} data-trackable="feed-link">{article.title}</a>
 					<span> – </span>
 					<time className="fast-ft__time" datetime={article.lastPublished}>{time}</time>
 				</h2>

--- a/components/layout/config.js
+++ b/components/layout/config.js
@@ -81,7 +81,7 @@ export default [
 		}
 	},
 	{
-		id: 'editors-pics',
+		id: 'editors-picks',
 		title: 'Editor\'s Picks',
 		style: 'editors-picks',
 		cards: {

--- a/components/section/section.js
+++ b/components/section/section.js
@@ -11,7 +11,7 @@ export default class Section extends Component {
 		const columns = columnConfig(!!this.props.sidebarContent);
 
 		return (
-			<section className={'section o-grid-container section--' + this.props.style}>
+			<section className={'section o-grid-container section--' + this.props.style} data-trackable={this.props.id}>
 				<div className="o-grid-row">
 					<div data-o-grid-colspan={columns[0]} className="section__column">
 						<SectionMeta title={this.props.title} date={this.props.date} />


### PR DESCRIPTION
/cc @ironsidevsquincy @andygout 

"Fixes" https://github.com/Financial-Times/next-front-page/issues/336 - with some differences.

* I prefer `top-stories` to `lead-today`as the trackable for top stories

* The `title` seems a bit superfluous in the example in the issue, so ditching that. The resulting trackable is: `opinion | card | main-link` on the new prototype.

I think it's fine to handle these differences in beacon as needed for now.
