### PR TITLE
Bump to n-layout v4 and fix dep resolutions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "o-date": "^2.0.0",
     "n-video": "^2.8.2",
     "n-message-prompts": "Financial-Times/n-message-prompts#^v1.0.0",
-    "n-layout": "^3.0.0",
+    "n-layout": "^4.0.0",
     "n-image": "^1.3.1",
     "o-fonts": "^1.8.4"
   },
@@ -17,6 +17,14 @@
     "lodash": "3.10.1-npm",
     "fetch": ">=0.10.0",
     "o-fonts": "^1.8.4",
-    "next-feature-flags-client": "~8.1.0"
+    "next-feature-flags-client": "~8.1.0",
+    "next-js-setup": "^6.0.0",
+    "o-errors": "^3.1.0",
+    "next-welcome": "^3.0.0",
+    "next-myft-ui": "^5.0.0",
+    "next-session-client": "^2.0.0",
+    "n-third-party-code": "^1.0.0",
+    "next-sass-setup": "7.0.4",
+    "next-myft-client": "^5.0.1"
   }
 }


### PR DESCRIPTION
We've introduced a breaking change to the `myft-client` which powers the save buttons on the homepage. This bumps to latest version. Sadly the dep resolutions are all needed but should only be temporary, I will clean up tomorrow.