### PR TITLE
Insert: Space between 'Last post' and 'x minutes ago'

### DIFF
--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -54,10 +54,10 @@
 			{{#ifEquals type 'LiveBlog'}}
 				<i class="liveblog__live-indicator"><i class="glow"></i></i>
 				{{#ifEquals status 'InProgress'}}
-					<span>last post</span>
+					<span>last post&nbsp;</span>
 				{{/ifEquals}}
 				{{#ifEquals status 'Closed'}}
-					<span>liveblog closed</span>
+					<span>liveblog closed&nbsp;</span>
 				{{/ifEquals}}
 
 				{{#ifEquals status 'ComingSoon'}}


### PR DESCRIPTION
cc @adgad @ironsidevsquincy 

Will now appear as '...CLOSED 35 MINUTES...' not '...CLOSED35 MINUTES...'

![screen shot 2015-11-05 at 14 30 27](https://cloud.githubusercontent.com/assets/10484515/10970998/d5c1ea08-83c9-11e5-88d3-f0050ee8c8fd.png)
