### PR TITLE
Make IE8 look less terrible

### DIFF
--- a/client/components/flexipod/main.scss
+++ b/client/components/flexipod/main.scss
@@ -5,6 +5,9 @@
 }
 
 @mixin nhFlexipodLayout($layout-spec) {
+	.article-group {
+		position: relative;
+	}
 	@if type-of($layout-spec) == list {
 		@for $int from 1 through length($layout-spec) {
 			$card-spec: nth($layout-spec, $int);

--- a/client/components/story-card/_footer.scss
+++ b/client/components/story-card/_footer.scss
@@ -1,16 +1,13 @@
 @mixin storyCardFooter {
 	@include nTypeAlpha(5);
 
-	position: absolute;
-	bottom: 0;
-	right: 0;
-	left: 0;
 	width: 100%;
-	border-bottom: 1px oColorsGetColorFor('card', 'border') solid;
+
 	text-transform: uppercase;
 	height: $story-card--footer-height;
 	padding: 0 10px;
 	line-height: $story-card--footer-height;
+	align-self: flex-end;
 
 	.time-icon {
 		margin-top: -3px;

--- a/client/components/story-card/main.scss
+++ b/client/components/story-card/main.scss
@@ -9,11 +9,13 @@
 
 .story-card {
 	background-color: oColorsGetColorFor('card', 'background');
+	border-bottom: 1px oColorsGetColorFor('card', 'border') solid;
 	margin-bottom: oGridGutter();
-	padding-bottom: $story-card--footer-height;
 	font-size: 18px;
 	width: 100%;
 	min-width: 0 !important;
+	display: flex;
+	flex-direction: column;
 
 	@include oGridRespondTo(M) {
 		margin-bottom: oGridGutter(M);
@@ -98,6 +100,10 @@
 	.story-card__related-link:nth-child(3) > & {
 		padding-right: 10px;
 	}
+}
+
+.story-card--inner {
+	flex-grow: 1;
 }
 
 .story-card__summary {

--- a/client/main.scss
+++ b/client/main.scss
@@ -38,7 +38,9 @@ html {
 
 	// Prevent navigation menus from creating
 	// extra space on sides of the page
-	overflow-x: hidden;
+	@include oGridRespondTo(S) {
+		overflow-x: hidden;
+	}
 }
 
 * {
@@ -107,9 +109,13 @@ body {
 		}
 	}
 
-	@include oGridRespondTo(L) {
+	.nh-header-tabs__tablist {
+		display: none;
+	}
+
+	@include oGridRespondTo($until: L) {
 		.nh-header-tabs__tablist {
-			display: none;
+			display: block;
 		}
 	}
 }
@@ -133,6 +139,7 @@ body {
 	.flexipod--lead-today {
 		// TODO think about sinking the breakpoints into nhFlexipod
 		@include nhFlexipod(map-get($layout-lead-today, default));
+		position: relative;
 
 		@include oGridRespondTo(XS) {
 			@include nhFlexipod(map-get($layout-lead-today, XS));
@@ -188,10 +195,10 @@ body {
 
 .sidebar {
 	&.sidebar--fastft {
-		display: none;
+		display: block;
 
-		@include oGridRespondTo($from: L) {
-			display: block;
+		@include oGridRespondTo($until: L) {
+			display: none;
 		}
 	}
 

--- a/components/fastft/main.scss
+++ b/components/fastft/main.scss
@@ -9,7 +9,7 @@
 	}
 
 	.fastft__logo__fast {
-		@include nextIcon(brand-fast, oColorsGetPaletteColor(fastft-brand), 40px);
+		@include nextIcon(brand-fast, oColorsGetPaletteColor(fastft-brand), 40);
 		text-indent: -9999px;
 		background-size: contain;
 		background-position: center;
@@ -17,7 +17,7 @@
 	}
 
 	.fastft__logo__ft {
-		@include nextIcon(brand-ft, oColorsGetPaletteColor(warm-4), 40px);
+		@include nextIcon(brand-ft, oColorsGetPaletteColor(warm-4), 40);
 		text-indent: -9999px;
 		background-size: contain;
 		background-position: center;

--- a/views/partials/carousel-card.html
+++ b/views/partials/carousel-card.html
@@ -1,4 +1,4 @@
-<article class="carousel-card article--{{genre}} o-grid-container o-grid-container--compact" tabindex="0" aria-labelledby="{{id}}-title" role="article">
+<article class="carousel-card article--{{genre}}" tabindex="0" aria-labelledby="{{id}}-title" role="article">
 	<div class="carousel-card--inner o-grid-row">
 		{{#if primaryImage}}
 			<a href="/content/{{id}}" class="carousel-card__image-link" role="presentation" aria-hidden="true" data-trackable="image-link">

--- a/views/partials/lead-today.html
+++ b/views/partials/lead-today.html
@@ -1,5 +1,5 @@
 {{#if items}}
-	<section class="flexipod flexipod--lead-today o-grid-container o-grid-container--compact" id="site-content" data-trackable="lead-today" role="region" tabindex="0" aria-labelledby="lead-pod-title">
+	<section class="flexipod flexipod--lead-today" id="site-content" data-trackable="lead-today" role="region" tabindex="0" aria-labelledby="lead-pod-title">
 		{{#if flags.popularTopics}}
 		<div class="pod-heading" role="presentation">
 			<h1 id="{{id}}-title" aria-hidden="true">Top stories</h1>

--- a/views/partials/opinion.html
+++ b/views/partials/opinion.html
@@ -7,7 +7,7 @@
 				<span>Go to Opinion</span>
 			</a>
 		</div>
-		<div class="o-grid-container o-grid-container--compact" role="presentation">
+		<div role="presentation">
 			<div class="article-group o-grid-row">
 				{{#slice items limit=1}}
 					<div class="article">

--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -52,40 +52,41 @@
 				</div>
 			</div>
 		{{/if}}
-		<div class='story-card__footer'>
-			{{#ifEquals type 'LiveBlog'}}
-				<i class="liveblog__live-indicator"><i class="glow"></i></i>
-				{{#ifEquals status 'InProgress'}}
-					<span>last post&nbsp;</span>
-				{{/ifEquals}}
-				{{#ifEquals status 'Closed'}}
-					<span>liveblog closed&nbsp;</span>
-				{{/ifEquals}}
+	</div>
 
-				{{#ifEquals status 'ComingSoon'}}
-					<span>coming soon</span>
-				{{else}}
-					{{#slice updates limit=1}}
-						<time
-							data-o-component="o-date"
-							class="o-date"
-							datetime="{{#dateformat}}{{date}}{{/dateformat}}">
-									{{#dateformat "dddd, d mmmm, yyyy"}}{{date}}{{/dateformat}}
-						</time>
-					{{/slice}}
-				{{/ifEquals}}
-			{{else}}
-				<span class="n-util-visually-hidden">Published</span>
-				<time
-					data-o-component="o-date"
-					class="o-date"
-					datetime="{{#dateformat}}{{lastPublished}}{{/dateformat}}">
-						{{#dateformat "dddd, d mmmm, yyyy"}}{{lastPublished}}{{/dateformat}}
-				</time>
+	<div class='story-card__footer'>
+		{{#ifEquals type 'LiveBlog'}}
+			<i class="liveblog__live-indicator"><i class="glow"></i></i>
+			{{#ifEquals status 'InProgress'}}
+				<span>last post&nbsp;</span>
 			{{/ifEquals}}
-			{{#unless related}}
-				{{>next-myft-ui/templates/save-for-later contentId=id}}
-			{{/unless}}
-		</div>
+			{{#ifEquals status 'Closed'}}
+				<span>liveblog closed&nbsp;</span>
+			{{/ifEquals}}
+
+			{{#ifEquals status 'ComingSoon'}}
+				<span>coming soon</span>
+			{{else}}
+				{{#slice updates limit=1}}
+					<time
+						data-o-component="o-date"
+						class="o-date"
+						datetime="{{#dateformat}}{{date}}{{/dateformat}}">
+								{{#dateformat "dddd, d mmmm, yyyy"}}{{date}}{{/dateformat}}
+					</time>
+				{{/slice}}
+			{{/ifEquals}}
+		{{else}}
+			<span class="n-util-visually-hidden">Published</span>
+			<time
+				data-o-component="o-date"
+				class="o-date"
+				datetime="{{#dateformat}}{{lastPublished}}{{/dateformat}}">
+					{{#dateformat "dddd, d mmmm, yyyy"}}{{lastPublished}}{{/dateformat}}
+			</time>
+		{{/ifEquals}}
+		{{#unless related}}
+			{{>next-myft-ui/templates/save-for-later contentId=id}}
+		{{/unless}}
 	</div>
 </article>

--- a/views/partials/topic.html
+++ b/views/partials/topic.html
@@ -7,7 +7,7 @@
 				<span>Go to {{title}}</span>
 			</a>
 		</div>
-		<div class="o-grid-container o-grid-container--compact" role="presentation">
+		<div role="presentation">
 			<div class="article-group o-grid-row">
 				{{#slice items limit=1}}
 					<div class="article">


### PR DESCRIPTION
* `o-grid-container` falls back to a fixed width, so removed uses of this within components that should be less than full width
* This enables fastFT and most popular content to be accessed on the front page, and makes things look less terrible
* Also only apply overflow-x on Small breakpoints since this is needed on pages that don't support media queries (needs to be done in next-sass-setup also) 

![ie8](https://cloud.githubusercontent.com/assets/1978880/11062661/9924f576-87a8-11e5-86cf-67eb48b2540b.gif)
