### PR TITLE
FastFT/Top Stories tabs

### DIFF
--- a/components/fast-ft/main.scss
+++ b/components/fast-ft/main.scss
@@ -9,6 +9,7 @@
 	}
 }
 .fast-ft {
+	width: 100%;
 	background-color: getColor('pink');
 	padding: 10px;
 	border-left: 1px solid getColor('warm-3');

--- a/components/section/main.scss
+++ b/components/section/main.scss
@@ -12,6 +12,10 @@
 	}
 }
 
+.section-nav {
+	padding-bottom: 0 !important;
+}
+
 .section__column {
 	align-items: stretch;
 	display: flex;
@@ -26,6 +30,34 @@
 		width: 100%;
 		padding-bottom: oGridGutter(M);
 		border-bottom: 1px solid oColorsGetPaletteColor('blue-2');
+	}
+}
+.section__column--meta {
+	// TODO: better way of defining this
+	.section--top-stories & {
+		@include oGridRespondTo($until: L) {
+			display: none;
+		}
+	}
+}
+.section__column--content {
+	#main-body .section--top-stories & {
+		#fast-ft-tab:target ~ & {
+			display: none;
+		}
+		#top-stories-tab:target ~ & {
+			display: block;
+		}
+	}
+}
+.section__column--sidebar {
+	#main-body .section--top-stories & {
+		@include oGridRespondTo($until: L) {
+			display: none;
+		}
+		#fast-ft-tab:target ~ & {
+			display: block;
+		}
 	}
 }
 

--- a/components/section/section.js
+++ b/components/section/section.js
@@ -3,7 +3,7 @@ import SectionMeta from './section-meta/section-meta';
 import SectionContent from './section-content/section-content';
 
 const columnConfig = (hasSidebar) => {
-	return hasSidebar ? ['12 XL2', '12 L10 XL8', 'hide L2'] : ['12 XL2', '12 XL10'];
+	return hasSidebar ? ['12 XL2', '12 L10 XL8', '12 L2'] : ['12 XL2', '12 XL10'];
 }
 
 export default class Section extends Component {
@@ -13,10 +13,10 @@ export default class Section extends Component {
 		return (
 			<section className={'section o-grid-container section--' + this.props.style} data-trackable={this.props.id}>
 				<div className="o-grid-row">
-					<div data-o-grid-colspan={columns[0]} className="section__column">
+					<div data-o-grid-colspan={columns[0]} className="section__column section__column--meta">
 						<SectionMeta title={this.props.title} date={this.props.date} />
 					</div>
-					<div data-o-grid-colspan={columns[1]} className="section__column">
+					<div data-o-grid-colspan={columns[1]} className="section__column section__column--content">
 						<SectionContent
 							style={this.props.style}
 							columns={this.props.columns}
@@ -26,7 +26,7 @@ export default class Section extends Component {
 					</div>
 					{
 						columns[2] ?
-						<aside data-o-grid-colspan={columns[2]} className="section__column">
+						<aside data-o-grid-colspan={columns[2]} className="section__column section__column--sidebar">
 							<this.props.sidebarComponent articles={this.props.sidebarContent.items} />
 						</aside>
 						: null

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -1,13 +1,13 @@
 {{#if @root.flags.frontPageLayoutPrototype}}
 	<div id="layout-overlay-container"></div>
-	<div id="top-stories-tab" class="nh-header-tabs__marker"></div>
-	<div id="fast-ft-tab" class="nh-header-tabs__marker"></div>
 	<div id="header-tabs" class="section-nav nh-header-tabs__tablist o-grid-container" data-trackable="section-nav">
 		<nav class="o-grid-row">
-			<a href="#top-stories-tab" data-trackable="top-stories" data-o-grid-colspan="6"><span>Top Stories</span></a>
+			<a href="#news-tab" data-trackable="top-stories" data-o-grid-colspan="6"><span>Top Stories</span></a>
 			<a href="#fast-ft-tab" data-trackable="fast-ft" data-o-grid-colspan="6"><span>fastFT</span></a>
 		</nav>
 	</div>
+	<div id="news-tab" class="nh-header-tabs__marker"></div>
+	<div id="fast-ft-tab" class="nh-header-tabs__marker"></div>
 	<section id="main-body" data-main-content="{{json content}}">{{{ reactRenderToString Layout content=content layout=initialLayout }}}</section>
 {{else}}
 	{{#defineBlock 'head'}}

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -1,5 +1,13 @@
 {{#if @root.flags.frontPageLayoutPrototype}}
 	<div id="layout-overlay-container"></div>
+	<div id="top-stories-tab" class="nh-header-tabs__marker"></div>
+	<div id="fast-ft-tab" class="nh-header-tabs__marker"></div>
+	<div id="header-tabs" class="section-nav nh-header-tabs__tablist o-grid-container" data-trackable="section-nav">
+		<nav class="o-grid-row">
+			<a href="#top-stories-tab" data-trackable="top-stories" data-o-grid-colspan="6"><span>Top Stories</span></a>
+			<a href="#fast-ft-tab" data-trackable="fast-ft" data-o-grid-colspan="6"><span>fastFT</span></a>
+		</nav>
+	</div>
 	<section id="main-body" data-main-content="{{json content}}">{{{ reactRenderToString Layout content=content layout=initialLayout }}}</section>
 {{else}}
 	{{#defineBlock 'head'}}
@@ -38,25 +46,25 @@
 			</div>
 		</div>
 	{{/if}}
-	
+
 <!--
-	
+
  FFFFFFFFFFFFFFFFFFFFFFTTTTTTTTTTTTTTTTTTTTTTT
  F::::::::::::::::::::FT:::::::::::::::::::::T
  F::::::::::::::::::::FT:::::::::::::::::::::T
  FF::::::FFFFFFFFF::::FT:::::TT:::::::TT:::::T
    F:::::F       FFFFFFTTTTTT  T:::::T  TTTTTT
-   F:::::F                     T:::::T        
-   F::::::FFFFFFFFFF           T:::::T        
-   F:::::::::::::::F           T:::::T        
-   F:::::::::::::::F           T:::::T        
-   F::::::FFFFFFFFFF           T:::::T        
-   F:::::F                     T:::::T        
-   F:::::F                     T:::::T        
- FF:::::::FF                 TT:::::::TT      
- F::::::::FF                 T:::::::::T      
- F::::::::FF                 T:::::::::T      
- FFFFFFFFFFF                 TTTTTTTTTTT  
+   F:::::F                     T:::::T
+   F::::::FFFFFFFFFF           T:::::T
+   F:::::::::::::::F           T:::::T
+   F:::::::::::::::F           T:::::T
+   F::::::FFFFFFFFFF           T:::::T
+   F:::::F                     T:::::T
+   F:::::F                     T:::::T
+ FF:::::::FF                 TT:::::::TT
+ F::::::::FF                 T:::::::::T
+ F::::::::FF                 T:::::::::T
+ FFFFFFFFFFF                 TTTTTTTTTTT
 
 Graduate? Hello! You've been inquisitive enough to find a link to our
 graduate scheme application.
@@ -68,7 +76,7 @@ Here's the promo code ... IFOUNDIT!
 Good luck!
 
 -->
-	
+
 	<div class="o-grid-container nh-header-tabs__panel">
 		<div class="o-grid-row">
 			<div class="main-content" data-o-grid-colspan="12 L9">


### PR DESCRIPTION
Basically copy existing next front page (will need to be revisited re: `target` pseudo-class)

![screen shot 2015-11-11 at 16 25 18](https://cloud.githubusercontent.com/assets/74132/11096213/d23cdebc-8890-11e5-97df-12ad98bcebbb.jpeg)

(licecap's gone screwy, so just a static image)
