### PR TITLE
Remove: Inline display from card image link class

### DIFF
--- a/components/card/image/main.scss
+++ b/components/card/image/main.scss
@@ -37,7 +37,6 @@
 	}
 
 	[data-card-landscape~="true"] & {
-		display: inline;
 		margin-top: 0;
 		margin-right: 10px;
 		order: -1;


### PR DESCRIPTION
cc @ironsidevsquincy 

Fix to make landscape cards work on IE10