### PR TITLE
Fix underline of fastFT logo

### DIFF
--- a/components/fast-ft/main.scss
+++ b/components/fast-ft/main.scss
@@ -15,7 +15,7 @@
 	border-left: 1px solid getColor('warm-3');
 }
 .fast-ft__link {
-	text-decoration: none;
+	border-bottom: 0;
 }
 .fast-ft__logo {
 	text-indent: -9999px;


### PR DESCRIPTION
This is what this line was intended to do… oops! [take 2]