### PR TITLE
IE 8/9 card fixes

### DIFF
--- a/client/main.scss
+++ b/client/main.scss
@@ -1,4 +1,3 @@
-$o-grid-ie8-rules: false;
 $o-grid-layouts: (
 	S:   490px,
 	M:   740px,

--- a/client/main.scss
+++ b/client/main.scss
@@ -1,3 +1,4 @@
+$o-grid-ie8-rules: false;
 $o-grid-layouts: (
 	S:   490px,
 	M:   740px,

--- a/components/card/image/main.scss
+++ b/components/card/image/main.scss
@@ -75,6 +75,12 @@
 }
 
 @each $layout-name in $_o-grid-layout-names {
+	[data-image-show~="#{$layout-name}--true"] .card__image {
+		display: block;
+	}
+	[data-image-show~="#{$layout-name}--false"] .card__image {
+		display: none;
+	}
 	@include oGridRespondTo($layout-name) {
 		[data-image-show~="#{$layout-name}--true"] .card__image {
 			display: block;

--- a/components/card/main.scss
+++ b/components/card/main.scss
@@ -61,6 +61,8 @@
 	@include oGridRespondTo($layout-name) {
 		[data-card-show~="#{$layout-name}--true"] {
 			display: flex;
+			/* IE8, IE9 */
+			display: block\0;
 		}
 
 		[data-card-show~="#{$layout-name}--false"] {

--- a/components/card/main.scss
+++ b/components/card/main.scss
@@ -58,6 +58,12 @@
 }
 
 @each $layout-name in $_o-grid-layout-names {
+	[data-card-show~="#{$layout-name}--true"] {
+		display: block;
+	}
+	[data-card-show~="#{$layout-name}--false"] {
+		display: none;
+	}
 	@include oGridRespondTo($layout-name) {
 		[data-card-show~="#{$layout-name}--true"] {
 			display: block;

--- a/components/card/main.scss
+++ b/components/card/main.scss
@@ -60,9 +60,8 @@
 @each $layout-name in $_o-grid-layout-names {
 	@include oGridRespondTo($layout-name) {
 		[data-card-show~="#{$layout-name}--true"] {
+			display: block;
 			display: flex;
-			/* IE8, IE9 */
-			display: block\0;
 		}
 
 		[data-card-show~="#{$layout-name}--false"] {

--- a/components/card/standfirst/main.scss
+++ b/components/card/standfirst/main.scss
@@ -23,6 +23,12 @@
 }
 
 @each $layout-name in $_o-grid-layout-names {
+	.card__standfirst[data-standfirst-show~="#{$layout-name}--true"] {
+		display: inherit;
+	}
+	.card__standfirst[data-standfirst-show~="#{$layout-name}--false"] {
+		display: none;
+	}
 	@include oGridRespondTo($layout-name) {
 		.card__standfirst[data-standfirst-show~="#{$layout-name}--true"] {
 			display: inherit;
@@ -35,6 +41,14 @@
 }
 
 @each $layout-name in $_o-grid-layout-names {
+	.card__standfirst--#{$layout-name}--large {
+		font-size: 22px;
+		line-height: 24px;
+	}
+	.card__standfirst--#{$layout-name}--medium {
+		font-size: 18px;
+		line-height: 20px;
+	}
 	@include oGridRespondTo($layout-name) {
 		.card__standfirst--#{$layout-name}--large {
 			font-size: 22px;


### PR DESCRIPTION
 * IE9 doesn't understand `display: flex`, so use `block` before
 * For IE8, `o-grid`'s colspan attribute uses the biggest display value, so need to the the same

![screen shot 2015-11-23 at 11 27 18](https://cloud.githubusercontent.com/assets/74132/11335590/68c497e2-91d5-11e5-84c9-b041b2ef3a1e.jpeg)

addresses a couple of https://github.com/Financial-Times/next-front-page/issues/362
