### PR TITLE
Don't use grid for ie8

### DIFF
--- a/client/main.scss
+++ b/client/main.scss
@@ -10,6 +10,7 @@ $o-grid-gutters: (
 	M:       15px
 );
 $o-grid-start-snappy-mode-at: XXL;
+$o-grid-ie8-rules: false;
 
 @import "n-layout/main";
 @import "next-myft-ui/main";

--- a/components/card/image/main.scss
+++ b/components/card/image/main.scss
@@ -19,21 +19,6 @@
 	}
 
 	@each $layout-name in $_o-grid-layout-names {
-		@media \0screen {
-			[data-image-show~="#{$layout-name}--true"] & {
-				display: flex;
-			}
-			[data-image-show~="#{$layout-name}--false"] & {
-				display: none;
-			}
-			[data-card-landscape~="#{$layout-name}--false"] & {
-				position: static;
-				top: 0;
-				left: 0;
-				width: auto;
-				margin-top: 10px;
-			}
-		}
 		@include oGridRespondTo($layout-name) {
 			[data-image-show~="#{$layout-name}--true"] & {
 				display: flex;

--- a/components/card/main.scss
+++ b/components/card/main.scss
@@ -41,29 +41,6 @@
 }
 
 @each $layout-name in $_o-grid-layout-names {
-	@media \0screen {
-		[data-card-show~="#{$layout-name}--true"] {
-			display: block;
-		}
-		[data-card-show~="#{$layout-name}--false"] {
-			display: none;
-		}
-		[data-card-landscape~="#{$layout-name}--true"] {
-			&[data-image-show~="true"] {
-				position: relative;
-				min-height: 56px;
-				padding-left: 120px;
-			}
-		}
-
-		[data-card-landscape~="#{$layout-name}--false"] {
-			&[data-image-show~="true"] {
-				position: static;
-				min-height: auto;
-				padding-left: 10px;
-			}
-		}
-	}
 	@include oGridRespondTo($layout-name) {
 		[data-card-show~="#{$layout-name}--true"] {
 			display: block;


### PR DESCRIPTION
Doesn't look as pretty in IE8, but saves on a whole load of headaches trying to get it to work without `oGridRespondTo`.

As it's core, and content is still accessible...

![screen shot 2015-11-27 at 15 46 25](https://cloud.githubusercontent.com/assets/74132/11444733/25b5f530-951e-11e5-9fab-f60f6ec7eebb.jpeg)
