### PR TITLE
Change top stories layout if top story has related content

### DIFF
--- a/components/layout/config.js
+++ b/components/layout/config.js
@@ -51,6 +51,26 @@ export default [
 				{ column: 2, width: 3, size: 'tiny' }
 			]
 		},
+		overrides: [
+			//Different layout if top story has related links
+			{
+				condition: (items) => {
+					return items[0] && items[0].relatedContent.length > 0;
+				},
+				cards: {
+					M: [
+						{ column: 0, width: 5, size: 'large', standFirst: true, image: true, related: 3 },
+						{ column: 1, width: 4, size: 'small' },
+						{ column: 1, width: 4, size: 'small' },
+						{ column: 1, width: 4, size: 'small' },
+						{ column: 1, width: 4, size: 'small' },
+						{ column: 2, width: 3, size: 'tiny' },
+						{ column: 2, width: 3, size: 'tiny' },
+						{ column: 2, width: 3, size: 'tiny', image: true },
+					]
+				}
+			}
+		],
 		size: {
 			default: 12
 		},

--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -39,6 +39,15 @@ export default class Layout extends Component {
 		const content = sectionContent(this.props.content);
 		const sections = this.props.layout.map(section => {
 			const sectionContent = content[section.id];
+
+			if(section.overrides) {
+				section.overrides.forEach((override) => {
+					if(override.condition(sectionContent.body)) {
+						section.cards = Object.assign(section.cards, override.cards);
+					}
+				});
+			}
+
 			return (
 				<div id={section.id} key={section.id} data-o-grid-colspan={colspan(section.size)}>
 					<Section {...section} content={sectionContent.body} sidebarContent={sectionContent.sidebar} data-o-grid-colspan="12" />


### PR DESCRIPTION
/cc @ironsidevsquincy 

Allow for config overrides based on conditions on the items. Not sure if this is clever or hacky/confusing, but can't think of a better way to do it!