### PR TITLE
don't minimize css before autoprefixing

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,9 +40,9 @@ const config = {
 				test: /\.scss|sass?$/,
 				loader: ExtractTextPlugin.extract(
 					[
-						'css?sourceMap&minimize',
+						'css?sourceMap',
 						'autoprefixer',
-						'sass?sourceMap&includePaths[]=' + (path.resolve(__dirname, './bower_components'))
+						'sass?sourceMap&outputStyle=nested&includePaths[]=' + (path.resolve(__dirname, './bower_components'))
 					].join('!')
 				)
 			}


### PR DESCRIPTION
Because otherwise autoprefixer config comments get stripped out before they are needed.

The css that's output is minified but god knows why. Don't know if css-clean is being applied either. 

Can we move front-page back to a standard build process please? (I agree it's worth us considering moving away from obt though)

@ironsidevsquincy @adgad 