### PR TITLE
More style fixes

### DIFF
--- a/components/card/image/main.scss
+++ b/components/card/image/main.scss
@@ -34,6 +34,14 @@
 				width: auto;
 				margin-top: 10px;
 			}
+
+			[data-card-landscape~="#{$layout-name}--true"] & {
+				position: absolute;
+				top: 10px;
+				left: 10px;
+				width: 100px;
+				margin-top: 0;
+			}
 		}
 	}
 }

--- a/components/layout/config.js
+++ b/components/layout/config.js
@@ -55,7 +55,7 @@ export default [
 			//Different layout if top story has related links
 			{
 				condition: (items) => {
-					return items[0] && items[0].relatedContent.length > 0;
+					return items[0] && items[0].relatedContent.length > 2;
 				},
 				cards: {
 					M: [

--- a/components/layout/config.js
+++ b/components/layout/config.js
@@ -279,6 +279,10 @@ export default [
 			M: [
 				{ size: 'small', image: true, landscape: false },
 				{ size: 'small' }
+			],
+			L: [
+				{ size: 'small', image: true, landscape: true },
+				{ size: 'small' }
 			]
 		},
 		size: {
@@ -310,6 +314,10 @@ export default [
 			M: [
 				{ size: 'small', image: true, landscape: false },
 				{ size: 'small' }
+			],
+			L: [
+				{ size: 'small', image: true, landscape: true },
+				{ size: 'small' }
 			]
 		},
 		size: {
@@ -340,6 +348,10 @@ export default [
 			],
 			M: [
 				{ size: 'small', image: true, landscape: false },
+				{ size: 'small' }
+			],
+			L: [
+				{ size: 'small', image: true, landscape: true },
 				{ size: 'small' }
 			]
 		},


### PR DESCRIPTION
/cc @ironsidevsquincy 
* Technology/Markets/Life & Arts cards will be landscape on L upwards
* Only do the related links reorganisation if there are 3 or more related links