### PR TITLE
Indent of related links

### DIFF
--- a/components/card/related/main.scss
+++ b/components/card/related/main.scss
@@ -4,25 +4,27 @@
 	list-style-type: none;
 }
 .card__related-item {
-	font-family: $n-type-sans-serif;
+	position: relative;
+	font-family: $o-typography-sans;
 	font-weight: oFontsWeight(light);
 	font-size: 18px;
 	line-height: 20px;
 	margin-top: 10px;
+	padding-left: 15px;
 }
 .card__related-item__link {
-	border-bottom: 0;
+	border-bottom-width: 0;
 	color: inherit;
 
 	&:hover {
 		border-bottom: 1px dotted;
 	}
 	&:before {
+		position: absolute;
+		top: 0;
+		left: 0;
 		content: '>';
 		font-size: 25px;
-		line-height: 0;
-		vertical-align: sub;
-		margin-right: 5px;
 	}
 }
 


### PR DESCRIPTION
### Before

![screen shot 2015-12-01 at 11 01 15](https://cloud.githubusercontent.com/assets/74132/11499034/1a29923a-981b-11e5-8c42-9032134185b2.jpeg)

### After

![screen shot 2015-12-01 at 11 01 11](https://cloud.githubusercontent.com/assets/74132/11499035/1d41b42a-981b-11e5-9be3-f7dcd3cfe707.jpeg)

Addresses part of https://github.com/Financial-Times/next-front-page/issues/371