### PR TITLE
If no javascript, don't display video section

### DIFF
--- a/components/section/main.scss
+++ b/components/section/main.scss
@@ -26,6 +26,12 @@
 	}
 }
 
+.section--video {
+	.no-js & {
+		display: none;
+	}
+}
+
 .section-nav {
 	padding-bottom: 0 !important;
 }


### PR DESCRIPTION
As js is needed to play the video inline, and on the page on video.ft.com, there's no point in showing the section if no js