### PR TITLE
Make blackberry 7 slightly less terrible

### DIFF
--- a/client/_flexbox-prefixed.scss
+++ b/client/_flexbox-prefixed.scss
@@ -1,0 +1,10 @@
+@mixin displayFlex() {
+	// Prevents autoprefixer from outputting display: -webkit-box;, which is buggy
+	& {
+		/*autoprefixer: off*/
+		display: -webkit-flex;
+		display: -ms-flexbox;
+		display: flex;
+	}
+
+}

--- a/client/components/flexipod/main.scss
+++ b/client/components/flexipod/main.scss
@@ -25,7 +25,7 @@
 		.article-group:nth-child(#{$int}) {
 			.article {
 				@include oGridColspan($width);
-				display: flex;
+				@include displayFlex;
 
 				.story-card {
 					@include nhStoryCard($type);
@@ -41,7 +41,7 @@
 
 				.article:nth-child(#{$card-int}) {
 					@include oGridColspan($width);
-					display: flex;
+					@include displayFlex;
 
 					.story-card {
 						@include nhStoryCard($type);

--- a/client/main.scss
+++ b/client/main.scss
@@ -12,6 +12,7 @@ $o-grid-gutters: (
 $o-grid-start-snappy-mode-at: XXL;
 $o-grid-ie8-rules: false;
 
+@import "flexbox-prefixed";
 @import "n-layout/main";
 @import "next-myft-ui/main";
 @import "n-video/main";

--- a/components/card/image/main.scss
+++ b/components/card/image/main.scss
@@ -1,5 +1,6 @@
 .card__image-link {
-	display: flex;
+	@include displayFlex;
+
 	flex: 1 1 auto;
 	align-items: flex-start;
 	margin-top: 10px;
@@ -20,7 +21,7 @@
 	@each $layout-name in $_o-grid-layout-names {
 		@include oGridRespondTo($layout-name) {
 			[data-card-has-image~="true"][data-image-show~="#{$layout-name}--true"] & {
-				display: flex;
+				@include displayFlex;
 			}
 
 			[data-image-show~="#{$layout-name}--false"] & {

--- a/components/card/main.scss
+++ b/components/card/main.scss
@@ -6,11 +6,13 @@
 @import './liveblog';
 
 .card {
+	@include displayFlex;
+
 	background-color: getColor('pink');
 	margin-top: oGridGutter();
 	border-bottom: 1px solid getColor('warm-3');
 	padding: 10px;
-	display: flex;
+
 	flex-direction: column;
 	line-height: 1;
 	flex: 1 1 auto;
@@ -45,7 +47,7 @@
 	@include oGridRespondTo($layout-name) {
 		[data-card-show~="#{$layout-name}--true"] {
 			display: block;
-			display: flex;
+			@include displayFlex;
 		}
 
 		[data-card-show~="#{$layout-name}--false"] {

--- a/components/section/main.scss
+++ b/components/section/main.scss
@@ -31,8 +31,9 @@
 }
 
 .section__column {
+	@include displayFlex;
 	align-items: stretch;
-	display: flex;
+
 
 	&[data-o-grid-colspan="hide L2"] {
 		@include oGridRespondTo($until: L) {
@@ -87,8 +88,8 @@
 }
 
 .column {
+	@include displayFlex;
 	flex-flow: column wrap;
-	display: flex;
 
 	&[data-o-grid-colspan~="hide"] {
 		@include oGridRespondTo($until: S) {

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -6,7 +6,7 @@
 {{#if @root.flags.frontPageLayoutPrototype}}
 	<div id="layout-overlay-container"></div>
 	{{> header-tabs  newsTabTitle="Top Stories"}}
-	<section id="main-body" class="main-body o-grid-container">
+	<section id="main-body" class="main-body o-grid-container n-util-clearfix">
 		{{{ reactRenderToString Layout content=content layout=initialLayout }}}
 	</section>
 {{else}}


### PR DESCRIPTION
/cc @wheresrhys @ironsidevsquincy @TheoLeanse @andygout 

* Apply the autoprefix fix on all front-page uses of flexbox
* Add a clearfix to the content container, to prevent footer overflowing (will probably move this to n-layout (around the footer itself) shortly)