### PR TITLE
Fix overflowing related links on certain breakpoints

### DIFF
--- a/components/section/main.scss
+++ b/components/section/main.scss
@@ -95,7 +95,7 @@
 
 .column {
 	@include displayFlex;
-	flex-flow: column;
+	flex-direction: column;
 
 	&[data-o-grid-colspan~="hide"] {
 		@include oGridRespondTo($until: S) {

--- a/components/section/main.scss
+++ b/components/section/main.scss
@@ -95,7 +95,7 @@
 
 .column {
 	@include displayFlex;
-	flex-flow: column wrap;
+	flex-flow: column;
 
 	&[data-o-grid-colspan~="hide"] {
 		@include oGridRespondTo($until: S) {


### PR DESCRIPTION
/cc @ironsidevsquincy 
Before: <img width="672" alt="screen shot 2015-12-03 at 15 04 11" src="https://cloud.githubusercontent.com/assets/1978880/11564291/5ff3c112-99d0-11e5-81c1-17a6ca69a497.png">

After: 
<img width="660" alt="screen shot 2015-12-03 at 15 04 19" src="https://cloud.githubusercontent.com/assets/1978880/11564296/655c89b8-99d0-11e5-83b7-5fe81ba372d5.png">
