### PR TITLE
Fire initial scroll depth tracking

### DIFF
--- a/client/components/scroll-depth/main.js
+++ b/client/components/scroll-depth/main.js
@@ -27,7 +27,7 @@ const init = () => {
 	scrollHandler();
 };
 
-module.exports = {
+export default {
 	init
 };
 

--- a/client/components/scroll-depth/main.js
+++ b/client/components/scroll-depth/main.js
@@ -1,10 +1,11 @@
-const fireTracking = require('../../utils/fire-tracking');
-const throttle = require('../../utils/throttle');
-const getDomPath = require('n-instrumentation/src/utils/getDomPath');
+import fireTracking from '../../utils/fire-tracking';
+import throttle from '../../utils/throttle';
+import getDomPath from 'n-instrumentation/src/utils/getDomPath';
 
 const toArray = nodeList => Array.prototype.slice.call(nodeList);
 
-const track = (componentEl, componentPos) => fireTracking('oTracking.event', { category: 'page', action: 'scrolldepth', componentPos: componentPos, domPath: getDomPath(componentEl, []) });
+const track = (componentEl, componentPos) =>
+	fireTracking('oTracking.event', { category: 'page', action: 'scrolldepth', componentPos, domPath: getDomPath(componentEl, []) });
 
 const scrollHandlerFactory = components => {
 	const componentsViewed = [];
@@ -20,9 +21,13 @@ const scrollHandlerFactory = components => {
 
 const init = () => {
 	const components = toArray(document.querySelectorAll('.flexipod, .section'));
-	window.addEventListener('scroll', throttle(scrollHandlerFactory(components), 250));
+	const scrollHandler = scrollHandlerFactory(components);
+	window.addEventListener('scroll', throttle(scrollHandler, 250));
+	// fire off an initial tracking
+	scrollHandler();
 };
 
 module.exports = {
 	init
 };
+


### PR DESCRIPTION
If the page jumps around (e.g. ads), the scroll event is fired, so fire off an initial scroll depth tracking to be safe

cc: @andygout 