### PR TITLE
Amend: Standfirst SCSS to fix size at M layout

### DIFF
--- a/components/card/standfirst/main.scss
+++ b/components/card/standfirst/main.scss
@@ -35,14 +35,6 @@
 }
 
 @each $layout-name in $_o-grid-layout-names {
-	.card__standfirst--#{$layout-name}--large {
-		font-size: 22px;
-		line-height: 24px;
-	}
-	.card__standfirst--#{$layout-name}--medium {
-		font-size: 18px;
-		line-height: 20px;
-	}
 	@include oGridRespondTo($layout-name) {
 		.card__standfirst--#{$layout-name}--large {
 			font-size: 22px;


### PR DESCRIPTION
cc @ironsidevsquincy 

Addresses part of https://github.com/Financial-Times/next-front-page/issues/371 (`change standfirst font size to 18px at M breakpoint (at the moment it's 22px, the same as the headline)`)