### PR TITLE
Handle pod headings that wrap onto two lines

### DIFF
--- a/client/_type.scss
+++ b/client/_type.scss
@@ -1,6 +1,6 @@
 @mixin podHeading {
 	@include nTypeAlpha(2);
-	padding: 10px 0;
+	line-height: 30px;
 	color: oColorsGetPaletteColor('warm-4');
 }
 
@@ -17,6 +17,7 @@
 	border: solid oColorsGetPaletteColor('warm-3');
 	border-width: 0 0 1px;
 	margin-bottom: 10px;
+	padding: 10px 0;
 
 	h1 {
 		@include podHeading;
@@ -57,27 +58,25 @@
 
 .pod-heading--link {
 	@include nTypeAlpha(3);
-	display: block;
-	padding-right: 10px;
+	margin-left: 10px;
+	line-height: 30px;
+	float: right;
 	border-bottom: 0;
+	color: oColorsGetPaletteColor('link-1');
 
-	span {
-		line-height: 40px;
-		float: right;
-		margin-right: 10px;
-		display: inline-block;
-		color: oColorsGetPaletteColor('link-1');
+	&:after {
+		@include nextIcon(go-to-circle, oColorsGetPaletteColor('link-1'), 30px);
+		content: '';
+		margin-left: 10px;
+		vertical-align: bottom;
 	}
 
 	&:hover,
 	&:active {
-		span {
-			color: oColorsGetPaletteColor('grey-tint5');
-		}
+		color: oColorsGetPaletteColor('grey-tint5');
 
-		.more-icon,
-		[data-alternate-text="More"] {
-			@include nextIcon(go-to-circle, oColorsGetPaletteColor('grey-tint5'), 30px);
+		&:after {
+			@include nextIcon(go-to-circle, oColorsGetPaletteColor('grey-tint5'), 30px, $icon-only: true);
 		}
 	}
 }

--- a/views/partials/opinion.html
+++ b/views/partials/opinion.html
@@ -2,10 +2,7 @@
 	<div class="flexipod flexipod--opinion" data-trackable="{{id}}" role="region" aria-labelledby="{{id}}-title">
 		<div class="pod-heading" role="presentation">
 			<h1 id="{{id}}-title" aria-hidden="true">{{title}}</h1>
-			<a class="pod-heading--link" href="{{url}}" data-trackable="go-to-link">
-				<i class="module-more-icon more-icon"></i>
-				<span>Go to Opinion</span>
-			</a>
+			<a class="pod-heading--link" href="{{url}}" data-trackable="go-to-link">Go to Opinion</a>
 		</div>
 		<div role="presentation">
 			<div class="article-group o-grid-row">

--- a/views/partials/topic.html
+++ b/views/partials/topic.html
@@ -2,10 +2,7 @@
 	<div class="flexipod flexipod--topic" data-trackable="topic-{{id}}" aria-labelledby="{{id}}-title" tabindex="0" role="region">
 		<div class="pod-heading" role="presentation">
 			<h1 id="{{id}}-title" aria-hidden="true">{{title}}</h1>
-			<a class="pod-heading--link" href="{{url}}" data-trackable="go-to-link">
-				<i class="module-more-icon more-icon"></i>
-				<span>Go to {{title}}</span>
-			</a>
+			<a class="pod-heading--link" href="{{url}}" data-trackable="go-to-link">Go to {{title}}</a>
 		</div>
 		<div role="presentation">
 			<div class="article-group o-grid-row">


### PR DESCRIPTION
### Before

![screen shot 2015-12-17 at 15 32 22](https://cloud.githubusercontent.com/assets/74132/11873616/68a315b6-a4d3-11e5-8690-b51616fcf71f.jpeg)

### After

![screen shot 2015-12-17 at 15 32 26](https://cloud.githubusercontent.com/assets/74132/11873621/6c2e126c-a4d3-11e5-9e2b-60a6addd6ae1.jpeg)
