### PR TITLE
Fix bizzare BB10 bug where prototype froze

### DIFF
--- a/components/section/node.js
+++ b/components/section/node.js
@@ -24,6 +24,7 @@ export default class SectionNode extends Component {
 
 	render () {
 		const cols = this.props.cols;
+		const trackable = this.props.trackable || this.props.id;
 		const sectionContentClasses = classify([
 			'section__column',
 			'section__column--content',
@@ -37,7 +38,7 @@ export default class SectionNode extends Component {
 		return (
 			<section
 				className={'section o-grid-container o-grid-container--compact section--' + this.props.style}
-				data-trackable={this.props.id + (this.state.selectedSource === 'initial' ? '' : ' | alternate-source')}>
+				data-trackable={trackable + (this.state.selectedSource === 'initial' ? '' : ' | alternate-source')}>
 				<div className="o-grid-row">
 					{
 						cols.meta ?

--- a/config/layout.js
+++ b/config/layout.js
@@ -501,7 +501,8 @@ export default [
 		}
 	},
 	{
-		id: 'video',
+		id: 'videos', // Note: calling this "video" breaks BB10
+		trackable: 'video',
 		title: 'Video',
 		style: 'video',
 		getContent: (content) => ({


### PR DESCRIPTION
@ironsidevsquincy 
*The bug:*
On a BB10 device (with working JS/polyfills), the page would freeze soon after loading, for about a minute, before becoming responsive again.

This was traced to happen on the front page prototype only. After much, much, much deleting and readding of code, it was traced to come from the iJento code - and in the network tab it could be seen that the request to `http://track.ft.com/track/track.js` was stuck pending for 1.2 minutes.

After much, much, much more deleting and readding of code - this was then traced down to the presence of a specific id on the page. The video id.

Why? God knows. Renaming fixes it ¯\_(ツ)_/¯