### PR TITLE
Output IE8 specific styles in their own stylesheet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,12 @@ watch-hot-load:
 	node server/dev/init
 
 build:
+	nbt build --main-sass ie8.scss --skip-js --skip-about --skip-haikro --skip-hash --dev
 	nbt build --dev
 
+
 build-production:
+	nbt build --main-sass ie8.scss --skip-js --skip-about --skip-haikro --skip-hash
 	nbt build
 
 smoke:

--- a/client/ie8.scss
+++ b/client/ie8.scss
@@ -1,0 +1,31 @@
+$o-grid-layouts: (
+	S:   490px,
+	M:   740px,
+	L:   980px,
+	XL:  1220px,
+	XXL: 1440px
+);
+$o-grid-gutters: (
+	default: 10px,
+	M:       15px
+);
+
+$o-grid-ie8-rules: 'only';
+
+@import "o-grid/main";
+// Mixins to ease the transition to o-grid v4
+@if not mixin-exists(oGridColumn) {
+	@mixin oGridColumn($args...) {
+		@warn "oGridColumn is deprecated. Please use oGridColspan instead.";
+		@include oGridColspan($args...);
+	}
+}
+
+
+// Surface current layout (for the JS helper)
+@include oGridSurfaceCurrentLayout;
+
+// Generate grid helper classes and data- attributes
+@include oGridGenerate;
+
+@import "../components/card/ie8";

--- a/client/main.scss
+++ b/client/main.scss
@@ -10,9 +10,12 @@ $o-grid-gutters: (
 	M:       15px
 );
 $o-grid-start-snappy-mode-at: XXL;
+//Turn off IE8 rules here and output them in an IE specific css file
+$o-grid-ie8-rules: false;
 
 @import "flexbox-prefixed";
 @import "n-layout/main";
+
 @import "next-myft-ui/main";
 @import "n-video/main";
 @import "n-message-prompts/main";

--- a/components/card/ie8.scss
+++ b/components/card/ie8.scss
@@ -1,0 +1,27 @@
+@import './image/ie8';
+
+@each $layout-name in $_o-grid-layout-names {
+	@include oGridTargetIE8 {
+		[data-card-show~="#{$layout-name}--true"] {
+			display: block;
+		}
+		[data-card-show~="#{$layout-name}--false"] {
+			display: none;
+		}
+		[data-card-landscape~="#{$layout-name}--true"] {
+			&[data-image-show~="true"] {
+				position: relative;
+				min-height: 56px;
+				padding-left: 120px;
+			}
+		}
+
+		[data-card-landscape~="#{$layout-name}--false"] {
+			&[data-card-has-image~="true"][data-image-show~="true"] {
+				position: static;
+				min-height: auto;
+				padding-left: 10px;
+			}
+		}
+	}
+}

--- a/components/card/image/ie8.scss
+++ b/components/card/image/ie8.scss
@@ -1,0 +1,24 @@
+.card__image-link {
+
+	@each $layout-name in $_o-grid-layout-names {
+		@include oGridTargetIE8 {
+			[data-image-show~="#{$layout-name}--true"] & {
+				display: flex;
+			}
+			[data-image-show~="#{$layout-name}--false"] & {
+				display: none;
+			}
+			[data-card-landscape~="#{$layout-name}--false"] & {
+				position: static;
+				top: 0;
+				left: 0;
+				width: auto;
+				margin-top: 10px;
+			}
+
+			[data-card-landscape~="#{$layout-name}--true"] & {
+				position: static;
+			}
+		}
+	}
+}

--- a/components/card/image/main.scss
+++ b/components/card/image/main.scss
@@ -19,25 +19,7 @@
 	}
 
 	@each $layout-name in $_o-grid-layout-names {
-		@include oGridTargetIE8 {
-			[data-image-show~="#{$layout-name}--true"] & {
-				display: flex;
-			}
-			[data-image-show~="#{$layout-name}--false"] & {
-				display: none;
-			}
-			[data-card-landscape~="#{$layout-name}--false"] & {
-				position: static;
-				top: 0;
-				left: 0;
-				width: auto;
-				margin-top: 10px;
-			}
 
-			[data-card-landscape~="#{$layout-name}--true"] & {
-				position: static;
-			}
-		}
 		@include oGridRespondTo($layout-name) {
 			[data-card-has-image~="true"][data-image-show~="#{$layout-name}--true"] & {
 				@include displayFlex;

--- a/components/section/section-content/section-content.js
+++ b/components/section/section-content/section-content.js
@@ -27,7 +27,7 @@ export default class SectionContent extends Component {
 		});
 
 		return (
-			<div className="o-grid-container--compact">
+			<div>
 				<div className="o-grid-row">
 					{columns}
 				</div>

--- a/components/section/section-content/section-content.js
+++ b/components/section/section-content/section-content.js
@@ -27,7 +27,7 @@ export default class SectionContent extends Component {
 		});
 
 		return (
-			<div className="o-grid-container o-grid-container--compact">
+			<div className="o-grid-container--compact">
 				<div className="o-grid-row">
 					{columns}
 				</div>

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -1,4 +1,7 @@
 {{#defineBlock 'head'}}
+	<!--[if lte IE 8]>
+		<link rel="stylesheet" href="{{#hashedAsset}}ie8.css{{/hashedAsset}}" />
+	<![endif]-->
 	<meta name="dfp_site" content="home" />
 	<meta name="dfp_zone" content="{{region}}" />
 {{/defineBlock}}

--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -1,4 +1,4 @@
-<article class="story-card article--{{genre}} {{#ifEquals contentType "LiveBlog"}}story-card--liveblog liveblog--{{lowercase status}}{{/ifEquals}} o-grid-container--compact" data-trackable="story" tabindex="0" aria-labelledby="{{id}}-title" role="article">
+<article class="story-card article--{{genre}} {{#ifEquals contentType "LiveBlog"}}story-card--liveblog liveblog--{{lowercase status}}{{/ifEquals}}" data-trackable="story" tabindex="0" aria-labelledby="{{id}}-title" role="article">
 	<div class="story-card--inner o-grid-row">
 		{{#if primaryImage}}
 			{{#unless hideImage}}
@@ -37,7 +37,7 @@
 		</div>
 		{{#if relatedContent}}
 			<div class="story-card__related--wrapper" data-o-grid-colspan="12">
-				<div class="story-card__related o-grid-container--compact" data-trackable="related-links" tabindex="0" role="group" aria-label="Related links">
+				<div class="story-card__related" data-trackable="related-links" tabindex="0" role="group" aria-label="Related links">
 					<div class="story-card__related--inline o-grid-row">
 						{{#slice relatedContent limit=3}}
 							<article class="story-card__related-link" aria-labelledby="{{id}}-title" tabindex="0" role="article" data-o-grid-colspan="12 M4">

--- a/views/partials/story-card.html
+++ b/views/partials/story-card.html
@@ -1,4 +1,4 @@
-<article class="story-card article--{{genre}} {{#ifEquals contentType "LiveBlog"}}story-card--liveblog liveblog--{{lowercase status}}{{/ifEquals}} o-grid-container o-grid-container--compact" data-trackable="story" tabindex="0" aria-labelledby="{{id}}-title" role="article">
+<article class="story-card article--{{genre}} {{#ifEquals contentType "LiveBlog"}}story-card--liveblog liveblog--{{lowercase status}}{{/ifEquals}} o-grid-container--compact" data-trackable="story" tabindex="0" aria-labelledby="{{id}}-title" role="article">
 	<div class="story-card--inner o-grid-row">
 		{{#if primaryImage}}
 			{{#unless hideImage}}
@@ -37,7 +37,7 @@
 		</div>
 		{{#if relatedContent}}
 			<div class="story-card__related--wrapper" data-o-grid-colspan="12">
-				<div class="story-card__related o-grid-container o-grid-container--compact" data-trackable="related-links" tabindex="0" role="group" aria-label="Related links">
+				<div class="story-card__related o-grid-container--compact" data-trackable="related-links" tabindex="0" role="group" aria-label="Related links">
 					<div class="story-card__related--inline o-grid-row">
 						{{#slice relatedContent limit=3}}
 							<article class="story-card__related-link" aria-labelledby="{{id}}-title" tabindex="0" role="article" data-o-grid-colspan="12 M4">


### PR DESCRIPTION
/cc @ironsidevsquincy @matthew-andrews 

Output IE8 specific grid/card styles in it's own stylesheet for moar performance (results in ~10% less CSS in main.css).

Removes o-grid-container from things that don't go full width (was previously working because .story-card etc css overrides the width, but now comes earlier - but I think o-grid-container should only be on full width things anyway).

Don't merge until https://github.com/Financial-Times/next-build-tools/pull/320 released