### PR TITLE
Remove unnecessary html

### DIFF
--- a/components/card/article.js
+++ b/components/card/article.js
@@ -23,8 +23,8 @@ class Article extends Component {
 		if (showCard.includes('false')) {
 			Object.assign(attrs, { 'data-show': showCard });
 		}
-		if (showImg.includes('true')) {
-			Object.assign(attrs, { 'data-has-image': hasImg, 'data-image-show': showImg });
+		if (showImg.includes('true') && hasImg) {
+			Object.assign(attrs, { 'data-image-show': showImg });
 
 			// landscape only applicable if there's an image
 			if (isLandscape.includes('true')) {
@@ -40,7 +40,7 @@ class Article extends Component {
 					{(article.primaryTag && article.primaryTag.taxonomy === 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
 				</div>
 				{showStandFirst.includes('true') ? <Standfirst article={article} size={this.props.standFirstSize} show={showStandFirst} /> : null}
-				{article.primaryImage && (showImg.includes('true')) ? <Image article={article} stickToBottom={this.props.imageStick}/> : null}
+				{(article.primaryImage && showImg.includes('true')) ? <Image article={article} stickToBottom={this.props.imageStick}/> : null}
 				{this.props.showRelated.length > 0 ? <Related articles={article.relatedContent} show={this.props.showRelated} /> : null}
 			</article>
 		);

--- a/components/card/article.js
+++ b/components/card/article.js
@@ -21,22 +21,24 @@ class Article extends Component {
 			'data-trackable': 'card'
 		};
 		if (showCard.includes('false')) {
-			Object.assign(attrs, { 'data-card-show': showCard });
+			Object.assign(attrs, { 'data-show': showCard });
 		}
 		if (showImg.includes('true')) {
-			Object.assign(attrs, { 'data-card-has-image': hasImg, 'data-image-show': showImg });
+			Object.assign(attrs, { 'data-has-image': hasImg, 'data-image-show': showImg });
 
 			// landscape only applicable if there's an image
 			if (isLandscape.includes('true')) {
-				Object.assign(attrs, { 'data-card-landscape': isLandscape });
+				Object.assign(attrs, { 'data-landscape': isLandscape });
 			}
 		}
 
 		return (
 			<article {...attrs}>
-				{(article.primaryTag && article.primaryTag.taxonomy !== 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
-				<Title title={article.title} href={'/content/' + article.id} size={this.props.titleSize} />
-				{(article.primaryTag && article.primaryTag.taxonomy === 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
+				<div>
+					{(article.primaryTag && article.primaryTag.taxonomy !== 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
+					<Title title={article.title} href={'/content/' + article.id} size={this.props.titleSize} />
+					{(article.primaryTag && article.primaryTag.taxonomy === 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
+				</div>
 				{showStandFirst.includes('true') ? <Standfirst article={article} size={this.props.standFirstSize} show={showStandFirst} /> : null}
 				{article.primaryImage && (showImg.includes('true')) ? <Image article={article} stickToBottom={this.props.imageStick}/> : null}
 				{this.props.showRelated.length > 0 ? <Related articles={article.relatedContent} show={this.props.showRelated} /> : null}

--- a/components/card/article.js
+++ b/components/card/article.js
@@ -12,6 +12,7 @@ class Article extends Component {
 	render () {
 		const article = this.props.article;
 		const hasImg = article.primaryImage ? 'true' : 'false';
+		const showStandFirst = responsiveValue(this.props.showStandFirst);
 		const showImg = responsiveValue(this.props.image);
 
 		return (
@@ -27,7 +28,7 @@ class Article extends Component {
 					<Title title={article.title} href={'/content/' + article.id} size={this.props.titleSize} />
 					{(article.primaryTag && article.primaryTag.taxonomy === 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
 				</div>
-				<Standfirst article={article} size={this.props.standFirstSize} show={this.props.showStandFirst} />
+				{showStandFirst.includes('true') ? <Standfirst article={article} size={this.props.standFirstSize} show={showStandFirst} /> : null}
 				{article.primaryImage && (showImg.includes('true')) ? <Image article={article} stickToBottom={this.props.imageStick}/> : null}
 				{this.props.showRelated.length > 0 ? <Related articles={article.relatedContent} show={this.props.showRelated} /> : null}
 			</article>

--- a/components/card/article.js
+++ b/components/card/article.js
@@ -11,7 +11,6 @@ import Related from './related/related';
 class Article extends Component {
 	render () {
 		const article = this.props.article;
-		const hasImg = article.primaryImage ? 'true' : 'false';
 		const showCard = responsiveValue(this.props.show);
 		const showStandFirst = responsiveValue(this.props.showStandFirst);
 		const showImg = responsiveValue(this.props.image);
@@ -23,7 +22,7 @@ class Article extends Component {
 		if (showCard.includes('false')) {
 			Object.assign(attrs, { 'data-show': showCard });
 		}
-		if (showImg.includes('true') && hasImg) {
+		if (article.primaryImage && showImg.includes('true')) {
 			Object.assign(attrs, { 'data-image-show': showImg });
 
 			// landscape only applicable if there's an image
@@ -39,7 +38,7 @@ class Article extends Component {
 					<Title title={article.title} href={'/content/' + article.id} size={this.props.titleSize} />
 					{(article.primaryTag && article.primaryTag.taxonomy === 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
 				</div>
-				{showStandFirst.includes('true') ? <Standfirst article={article} size={this.props.standFirstSize} show={showStandFirst} /> : null}
+				{(article.summary && showStandFirst.includes('true')) ? <Standfirst article={article} size={this.props.standFirstSize} show={this.props.showStandFirst} /> : null}
 				{(article.primaryImage && showImg.includes('true')) ? <Image article={article} stickToBottom={this.props.imageStick}/> : null}
 				{this.props.showRelated.length > 0 ? <Related articles={article.relatedContent} show={this.props.showRelated} /> : null}
 			</article>

--- a/components/card/article.js
+++ b/components/card/article.js
@@ -20,7 +20,7 @@ class Article extends Component {
 			className: 'card',
 			'data-trackable': 'card'
 		};
-		if (showCard !== 'true') {
+		if (showCard.includes('false')) {
 			Object.assign(attrs, { 'data-card-show': showCard });
 		}
 		if (showImg.includes('true')) {

--- a/components/card/article.js
+++ b/components/card/article.js
@@ -12,22 +12,31 @@ class Article extends Component {
 	render () {
 		const article = this.props.article;
 		const hasImg = article.primaryImage ? 'true' : 'false';
+		const showCard = responsiveValue(this.props.show);
 		const showStandFirst = responsiveValue(this.props.showStandFirst);
 		const showImg = responsiveValue(this.props.image);
+		const isLandscape = responsiveValue(this.props.landscape);
+		const attrs = {
+			className: 'card',
+			'data-trackable': 'card'
+		};
+		if (showCard !== 'true') {
+			Object.assign(attrs, { 'data-card-show': showCard });
+		}
+		if (showImg.includes('true')) {
+			Object.assign(attrs, { 'data-card-has-image': hasImg, 'data-image-show': showImg });
+
+			// landscape only applicable if there's an image
+			if (isLandscape.includes('true')) {
+				Object.assign(attrs, { 'data-card-landscape': isLandscape });
+			}
+		}
 
 		return (
-			<article
-					className="card"
-					data-card-landscape={responsiveValue(this.props.landscape)}
-					data-trackable="card"
-					data-card-show={responsiveValue(this.props.show)}
-					data-card-has-image={hasImg}
-					data-image-show={showImg}>
-				<div>
-					{(article.primaryTag && article.primaryTag.taxonomy !== 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
-					<Title title={article.title} href={'/content/' + article.id} size={this.props.titleSize} />
-					{(article.primaryTag && article.primaryTag.taxonomy === 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
-				</div>
+			<article {...attrs}>
+				{(article.primaryTag && article.primaryTag.taxonomy !== 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
+				<Title title={article.title} href={'/content/' + article.id} size={this.props.titleSize} />
+				{(article.primaryTag && article.primaryTag.taxonomy === 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
 				{showStandFirst.includes('true') ? <Standfirst article={article} size={this.props.standFirstSize} show={showStandFirst} /> : null}
 				{article.primaryImage && (showImg.includes('true')) ? <Image article={article} stickToBottom={this.props.imageStick}/> : null}
 				{this.props.showRelated.length > 0 ? <Related articles={article.relatedContent} show={this.props.showRelated} /> : null}

--- a/components/card/helpers.js
+++ b/components/card/helpers.js
@@ -37,7 +37,12 @@ const responsiveClass = (component, modifier) => {
 	// this is a crucial step in order not to output ridiculous classes
 	const mod = mobileFirst(modifier);
 
-	return prefix(component, mod.default) + ' ' + layoutNames.filter(it => mod.hasOwnProperty(it)).map(l => prefix(component, mod[l], l)).join(' ');
+	return [
+		prefix(component, mod.default),
+		...layoutNames
+			.filter(it => mod.hasOwnProperty(it))
+			.map(l => prefix(component, mod[l], l))
+	].join(' ');
 };
 
 // Public: turns an object like {default: 'val', S: 'other-val'}

--- a/components/card/helpers.js
+++ b/components/card/helpers.js
@@ -33,9 +33,9 @@ const prefix = (klass, modifier, layout) => {
 
 // Public: turns a component name (e.g. foo) and an object like {default: 'val', S: 'other-val'}
 // to a string 'foo--val foo--S--other-val'
-const responsiveClass = (component, modifier) => {
+const responsiveClass = (component, modifier, allModifiers = false) => {
 	// this is a crucial step in order not to output ridiculous classes
-	const mod = mobileFirst(modifier);
+	const mod = allModifiers ? modifier : mobileFirst(modifier);
 
 	return [
 		prefix(component, mod.default),
@@ -47,8 +47,8 @@ const responsiveClass = (component, modifier) => {
 
 // Public: turns an object like {default: 'val', S: 'other-val'}
 // to a string 'val S--other-val'
-const responsiveValue = (value) => {
-	return responsiveClass('', value);
+const responsiveValue = (value, allValues = false) => {
+	return responsiveClass('', value, allValues);
 };
 
 export default {

--- a/components/card/helpers.js
+++ b/components/card/helpers.js
@@ -16,7 +16,7 @@ const mobileFirst = (value) => {
 	return cleanValue;
 };
 
-// Public: maps a function over an object returnin a new object
+// Public: maps a function over an object returning a new object
 // with the same keys and values replaced with the result of the function.
 // The callback has a signature '(value, key) => value'
 const objMap = (object, fn) => {

--- a/components/card/ie8.scss
+++ b/components/card/ie8.scss
@@ -2,26 +2,22 @@
 
 @each $layout-name in $_o-grid-layout-names {
 	@include oGridTargetIE8 {
-		[data-card-show~="#{$layout-name}--true"] {
+		.card[data-show~="#{$layout-name}--true"] {
 			display: block;
 		}
-		[data-card-show~="#{$layout-name}--false"] {
+		.card[data-show~="#{$layout-name}--false"] {
 			display: none;
 		}
-		[data-card-landscape~="#{$layout-name}--true"] {
-			&[data-image-show~="true"] {
-				position: relative;
-				min-height: 56px;
-				padding-left: 120px;
-			}
+		.card[data-landscape~="#{$layout-name}--true"] {
+			position: relative;
+			min-height: 56px;
+			padding-left: 120px;
 		}
 
-		[data-card-landscape~="#{$layout-name}--false"] {
-			&[data-card-has-image~="true"][data-image-show~="true"] {
-				position: static;
-				min-height: auto;
-				padding-left: 10px;
-			}
+		.card[data-landscape~="#{$layout-name}--false"] {
+			position: static;
+			min-height: auto;
+			padding-left: 10px;
 		}
 	}
 }

--- a/components/card/image/ie8.scss
+++ b/components/card/image/ie8.scss
@@ -2,13 +2,13 @@
 
 	@each $layout-name in $_o-grid-layout-names {
 		@include oGridTargetIE8 {
-			[data-image-show~="#{$layout-name}--true"] & {
+			.card[data-image-show~="#{$layout-name}--true"] & {
 				display: flex;
 			}
-			[data-image-show~="#{$layout-name}--false"] & {
+			.card[data-image-show~="#{$layout-name}--false"] & {
 				display: none;
 			}
-			[data-card-landscape~="#{$layout-name}--false"] & {
+			.card[data-landscape~="#{$layout-name}--false"] & {
 				position: static;
 				top: 0;
 				left: 0;
@@ -16,7 +16,7 @@
 				margin-top: 10px;
 			}
 
-			[data-card-landscape~="#{$layout-name}--true"] & {
+			.card[data-landscape~="#{$layout-name}--true"] & {
 				position: static;
 			}
 		}

--- a/components/card/image/main.scss
+++ b/components/card/image/main.scss
@@ -6,7 +6,7 @@
 	margin-top: 10px;
 	border-bottom: 0;
 
-	[data-card-landscape~="true"] & {
+	.card[data-landscape~="true"] & {
 		position: absolute;
 		top: 10px;
 		left: 10px;
@@ -14,22 +14,21 @@
 		margin-top: 0;
 	}
 
-	[data-image-show~="false"] & {
+	.card[data-image-show~="false"] & {
 		display: none;
 	}
 
 	@each $layout-name in $_o-grid-layout-names {
-
 		@include oGridRespondTo($layout-name) {
-			[data-card-has-image~="true"][data-image-show~="#{$layout-name}--true"] & {
+			.card[data-has-image~="true"][data-image-show~="#{$layout-name}--true"] & {
 				@include displayFlex;
 			}
 
-			[data-image-show~="#{$layout-name}--false"] & {
+			.card[data-image-show~="#{$layout-name}--false"] & {
 				display: none;
 			}
 
-			[data-card-landscape~="#{$layout-name}--false"] & {
+			.card[data-landscape~="#{$layout-name}--false"] & {
 				position: static;
 				top: 0;
 				left: 0;
@@ -37,7 +36,7 @@
 				margin-top: 10px;
 			}
 
-			[data-card-landscape~="#{$layout-name}--true"] & {
+			.card[data-landscape~="#{$layout-name}--true"] & {
 				position: absolute;
 				top: 10px;
 				left: 10px;
@@ -52,17 +51,17 @@
 .card__image-link--headshot {
 	align-items: flex-end;
 
-	[data-card-landscape~="true"] & {
+	.card[data-landscape~="true"] & {
 		align-items: flex-start;
 	}
 
-	[data-card-landscape~="S--false"] & {
+	.card[data-landscape~="S--false"] & {
 		@include oGridRespondTo(S) {
 			align-items: flex-end;
 		}
 	}
 
-	[data-card-landscape~="M--false"] & {
+	.card[data-landscape~="M--false"] & {
 		@include oGridRespondTo(M) {
 			align-items: flex-end;
 		}

--- a/components/card/image/main.scss
+++ b/components/card/image/main.scss
@@ -68,17 +68,6 @@
 	}
 }
 
-@each $layout-name in $_o-grid-layout-names {
-	@include oGridRespondTo($layout-name) {
-		.card__image-link--stick {
-			align-items: flex-end;
-		}
-		.card__image-link--no-stick {
-			align-items: flex-start;
-		}
-	}
-}
-
 .card__image {
 	display: block;
 	width: 100%;

--- a/components/card/image/main.scss
+++ b/components/card/image/main.scss
@@ -20,7 +20,7 @@
 
 	@each $layout-name in $_o-grid-layout-names {
 		@include oGridRespondTo($layout-name) {
-			.card[data-has-image~="true"][data-image-show~="#{$layout-name}--true"] & {
+			.card[data-image-show~="#{$layout-name}--true"] & {
 				@include displayFlex;
 			}
 

--- a/components/card/liveBlog.js
+++ b/components/card/liveBlog.js
@@ -18,10 +18,10 @@ class LiveBlog extends Component {
 		return (
 			<article
 					className={"card card--liveblog liveblog--" + article.status.toLowerCase()}
-					data-card-landscape={responsiveValue(this.props.landscape)}
+					data-landscape={responsiveValue(this.props.landscape)}
 					data-trackable="card"
-					data-card-show={responsiveValue(this.props.show)}
-					data-card-has-image={hasImg}
+					data-show={responsiveValue(this.props.show)}
+					data-has-image={hasImg}
 					data-image-show={responsiveValue(this.props.image)}>
 				<div>
 					<span className="liveblog__badge">live</span>

--- a/components/card/liveBlog.js
+++ b/components/card/liveBlog.js
@@ -12,25 +12,38 @@ import Standfirst from './standfirst/standfirst'
 class LiveBlog extends Component {
 	render () {
 		const article = this.props.liveBlog;
+		const hasImg = article.primaryImage ? 'true' : 'false';
+		const showCard = responsiveValue(this.props.show);
+		const showStandFirst = responsiveValue(this.props.showStandFirst);
+		const showImg = responsiveValue(this.props.image);
+		const isLandscape = responsiveValue(this.props.landscape);
+		const attrs = {
+			className: 'card card--liveblog liveblog--' + article.status.toLowerCase(),
+			'data-trackable': 'card'
+		};
+		if (showCard.includes('false')) {
+			Object.assign(attrs, { 'data-show': showCard });
+		}
+		if (showImg.includes('true')) {
+			Object.assign(attrs, { 'data-has-image': hasImg, 'data-image-show': showImg });
+
+			// landscape only applicable if there's an image
+			if (isLandscape.includes('true')) {
+				Object.assign(attrs, { 'data-landscape': isLandscape });
+			}
+		}
 
 		article.summary = article.updates.length ? article.updates[0].text.split(/\.\s/).slice(0, 1) + '.' : null;
-		const hasImg = article.primaryImage ? 'true' : 'false';
 		return (
-			<article
-					className={"card card--liveblog liveblog--" + article.status.toLowerCase()}
-					data-landscape={responsiveValue(this.props.landscape)}
-					data-trackable="card"
-					data-show={responsiveValue(this.props.show)}
-					data-has-image={hasImg}
-					data-image-show={responsiveValue(this.props.image)}>
+			<article {...attrs}>
 				<div>
 					<span className="liveblog__badge">live</span>
 					{(article.primaryTag && article.primaryTag.taxonomy !== 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
 					<Title title={article.title} href={'/content/' + article.id} size={this.props.titleSize} />
 					{(article.primaryTag && article.primaryTag.taxonomy === 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
 				</div>
-				<Standfirst article={article} size='medium' show={this.props.showStandFirst} />
-				{article.primaryImage ? <Image article={article} show={this.props.image} stickToBottom={this.props.imageStick}/> : null}
+				{showStandFirst.includes('true') ? <Standfirst article={article} size='medium' show={this.props.showStandFirst} /> : null}
+				{(article.primaryImage && showImg.includes('true')) ? <Image article={article} stickToBottom={this.props.imageStick}/> : null}
 				{this.props.showRelated.length > 0 ? <Related articles={article.relatedContent} show={this.props.showRelated} /> : null}
 				<div className="card__footer">
 					<i className="liveblog__live-indicator"><i className="glow"></i></i>

--- a/components/card/liveBlog.js
+++ b/components/card/liveBlog.js
@@ -12,7 +12,6 @@ import Standfirst from './standfirst/standfirst'
 class LiveBlog extends Component {
 	render () {
 		const article = this.props.liveBlog;
-		const hasImg = article.primaryImage ? 'true' : 'false';
 		const showCard = responsiveValue(this.props.show);
 		const showStandFirst = responsiveValue(this.props.showStandFirst);
 		const showImg = responsiveValue(this.props.image);
@@ -24,8 +23,8 @@ class LiveBlog extends Component {
 		if (showCard.includes('false')) {
 			Object.assign(attrs, { 'data-show': showCard });
 		}
-		if (showImg.includes('true')) {
-			Object.assign(attrs, { 'data-has-image': hasImg, 'data-image-show': showImg });
+		if (article.primaryImage && showImg.includes('true')) {
+			Object.assign(attrs, { 'data-image-show': showImg });
 
 			// landscape only applicable if there's an image
 			if (isLandscape.includes('true')) {
@@ -42,7 +41,7 @@ class LiveBlog extends Component {
 					<Title title={article.title} href={'/content/' + article.id} size={this.props.titleSize} />
 					{(article.primaryTag && article.primaryTag.taxonomy === 'authors') ? <Tag tag={article.primaryTag} size={this.props.tagSize} /> : null}
 				</div>
-				{showStandFirst.includes('true') ? <Standfirst article={article} size='medium' show={this.props.showStandFirst} /> : null}
+				{(article.summary && showStandFirst.includes('true')) ? <Standfirst article={article} size="medium" show={this.props.showStandFirst} /> : null}
 				{(article.primaryImage && showImg.includes('true')) ? <Image article={article} stickToBottom={this.props.imageStick}/> : null}
 				{this.props.showRelated.length > 0 ? <Related articles={article.relatedContent} show={this.props.showRelated} /> : null}
 				<div className="card__footer">

--- a/components/card/main.scss
+++ b/components/card/main.scss
@@ -27,12 +27,12 @@
 	padding: 0;
 }
 
-[data-card-show~="false"] {
+.card[data-show~="false"] {
 	display: none;
 }
 
-[data-card-landscape~="true"] {
-	&[data-card-has-image~="true"][data-image-show~="true"] {
+.card[data-landscape~="true"] {
+	&[data-has-image~="true"][data-image-show~="true"] {
 		position: relative;
 		min-height: 56px;
 		padding-left: 120px;
@@ -45,12 +45,12 @@
 
 @each $layout-name in $_o-grid-layout-names {
 	@include oGridRespondTo($layout-name) {
-		[data-card-show~="#{$layout-name}--true"] {
+		.card[data-show~="#{$layout-name}--true"] {
 			display: block;
 			@include displayFlex;
 		}
 
-		[data-card-show~="#{$layout-name}--false"] {
+		.card[data-show~="#{$layout-name}--false"] {
 			display: none;
 		}
 
@@ -62,16 +62,16 @@
 			flex: none;
 		}
 
-		[data-card-landscape~="#{$layout-name}--true"] {
-			&[data-card-has-image~="true"][data-image-show~="true"] {
+		.card[data-landscape~="#{$layout-name}--true"] {
+			&[data-has-image~="true"][data-image-show~="true"] {
 				position: relative;
 				min-height: 56px;
 				padding-left: 120px;
 			}
 		}
 
-		[data-card-landscape~="#{$layout-name}--false"] {
-			&[data-card-has-image~="true"][data-image-show~="true"] {
+		.card[data-landscape~="#{$layout-name}--false"] {
+			&[data-has-image~="true"][data-image-show~="true"] {
 				position: static;
 				min-height: auto;
 				padding-left: 10px;

--- a/components/card/main.scss
+++ b/components/card/main.scss
@@ -32,11 +32,9 @@
 }
 
 .card[data-landscape~="true"] {
-	&[data-has-image~="true"][data-image-show~="true"] {
-		position: relative;
-		min-height: 56px;
-		padding-left: 120px;
-	}
+	position: relative;
+	min-height: 56px;
+	padding-left: 120px;
 }
 
 .card--no-stretch {
@@ -63,19 +61,15 @@
 		}
 
 		.card[data-landscape~="#{$layout-name}--true"] {
-			&[data-has-image~="true"][data-image-show~="true"] {
-				position: relative;
-				min-height: 56px;
-				padding-left: 120px;
-			}
+			position: relative;
+			min-height: 56px;
+			padding-left: 120px;
 		}
 
 		.card[data-landscape~="#{$layout-name}--false"] {
-			&[data-has-image~="true"][data-image-show~="true"] {
-				position: static;
-				min-height: auto;
-				padding-left: 10px;
-			}
+			position: static;
+			min-height: auto;
+			padding-left: 10px;
 		}
 	}
 }

--- a/components/card/related/main.scss
+++ b/components/card/related/main.scss
@@ -3,6 +3,7 @@
 	padding: 0;
 	list-style-type: none;
 }
+
 .card__related-item {
 	position: relative;
 	font-family: $o-typography-sans;
@@ -12,6 +13,23 @@
 	margin-top: 10px;
 	padding-left: 15px;
 }
+
+.card__related-item[data-show~="false"] {
+	display: none;
+}
+
+@each $layout-name in $_o-grid-layout-names {
+	@include oGridRespondTo($layout-name) {
+		.card__related-item[data-show~="#{$layout-name}--true"] {
+			display: block;
+		}
+
+		.card__related-item[data-show~="#{$layout-name}--false"] {
+			display: none;
+		}
+	}
+}
+
 .card__related-item__link {
 	border-bottom-width: 0;
 	color: inherit;
@@ -25,21 +43,5 @@
 		left: 0;
 		content: '>';
 		font-size: 25px;
-	}
-}
-
-[data-related-show~="false"] {
-	display: none;
-}
-
-@each $layout-name in $_o-grid-layout-names {
-	@include oGridRespondTo($layout-name) {
-		[data-related-show~="#{$layout-name}--true"] {
-			display: block;
-		}
-
-		[data-related-show~="#{$layout-name}--false"] {
-			display: none;
-		}
 	}
 }

--- a/components/card/related/related.js
+++ b/components/card/related/related.js
@@ -7,9 +7,11 @@ export default class Related extends Component {
 		const relatedEls = this.props.show.map((show, i) => {
 			const related = articles[i];
 
-			return (<li className="card__related-item" key={related.id} data-related-show={responsiveValue(show)}>
-				<a href={'/content/' + related.id} className="card__related-item__link" data-trackable="related">{related.title}</a>
-			</li>)
+			return (
+				<li className="card__related-item" key={related.id} data-show={responsiveValue(show)}>
+					<a href={'/content/' + related.id} className="card__related-item__link" data-trackable="related">{related.title}</a>
+				</li>
+			);
 		});
 
 		return (

--- a/components/card/standfirst/main.scss
+++ b/components/card/standfirst/main.scss
@@ -3,54 +3,43 @@
 	font-weight: oFontsWeight(light);
 	margin: 5px 0 0;
 }
-.card__standfirst--large {
-	font-size: 22px;
-	line-height: 24px;
-}
-.card__standfirst--medium {
+
+.card__standfirst[data-size~="medium"] {
 	font-size: 18px;
 	line-height: 20px;
 }
 
-.card__standfirst[data-standfirst-show~="false"] {
+.card__standfirst[data-size~="large"] {
+	font-size: 22px;
+	line-height: 24px;
+}
+
+.card__standfirst[data-show~="false"] {
 	display: none;
 }
 
 @each $layout-name in $_o-grid-layout-names {
-	.card__standfirst[data-standfirst-show~="#{$layout-name}--true"] {
-		display: inherit;
-	}
-	.card__standfirst[data-standfirst-show~="#{$layout-name}--false"] {
-		display: none;
-	}
 	@include oGridRespondTo($layout-name) {
-		.card__standfirst[data-standfirst-show~="#{$layout-name}--true"] {
-			display: inherit;
+		.card__standfirst[data-show~="#{$layout-name}--false"] {
+			display: none;
 		}
 
-		.card__standfirst[data-standfirst-show~="#{$layout-name}--false"] {
-			display: none;
+		.card__standfirst[data-show~="#{$layout-name}--true"] {
+			display: inherit;
 		}
 	}
 }
 
 @each $layout-name in $_o-grid-layout-names {
-	.card__standfirst--#{$layout-name}--large {
-		font-size: 22px;
-		line-height: 24px;
-	}
-	.card__standfirst--#{$layout-name}--medium {
-		font-size: 18px;
-		line-height: 20px;
-	}
 	@include oGridRespondTo($layout-name) {
-		.card__standfirst--#{$layout-name}--large {
-			font-size: 22px;
-			line-height: 24px;
-		}
-		.card__standfirst--#{$layout-name}--medium {
+		.card__standfirst[data-size~="#{$layout-name}--medium"] {
 			font-size: 18px;
 			line-height: 20px;
+		}
+
+		.card__standfirst[data-size~="#{$layout-name}--large"] {
+			font-size: 22px;
+			line-height: 24px;
 		}
 	}
 }

--- a/components/card/standfirst/standfirst.js
+++ b/components/card/standfirst/standfirst.js
@@ -1,13 +1,14 @@
 import React, {Component} from 'react';
-import {responsiveClass, responsiveValue} from '../helpers';
+import {responsiveValue} from '../helpers';
 
 export default class Standfirst extends Component {
 	render () {
 		const article = this.props.article;
 
 		return (
-			<p className={'card__standfirst ' + responsiveClass('card__standfirst', this.props.size)}
-				 data-standfirst-show={responsiveValue(this.props.show)}>
+			<p className="card__standfirst"
+				data-size={responsiveValue(this.props.size)}
+				data-show={responsiveValue(this.props.show)}>
 				{article.summary}
 			</p>
 		);

--- a/components/card/tag/main.scss
+++ b/components/card/tag/main.scss
@@ -25,7 +25,7 @@
 	color: getColor(claret);
 }
 
-.card__tag--tiny {
+.card__tag[data-size~="tiny"] {
 	display: inline;
 
 	&:first-child {
@@ -40,7 +40,7 @@
 
 @each $layout-name in $_o-grid-layout-names {
 	@include oGridRespondTo($layout-name) {
-		.card__tag--#{$layout-name}--tiny {
+		.card__tag[data-size~="#{$layout-name}--tiny"] {
 			display: inline;
 
 			&:first-child {
@@ -52,10 +52,10 @@
 				}
 			}
 		}
-		.card__tag--#{$layout-name}--small,
-		.card__tag--#{$layout-name}--medium,
-		.card__tag--#{$layout-name}--large,
-		.card__tag--#{$layout-name}--huge {
+		.card__tag[data-size~="#{$layout-name}--small"],
+		.card__tag[data-size~="#{$layout-name}--medium"],
+		.card__tag[data-size~="#{$layout-name}--large"],
+		.card__tag[data-size~="#{$layout-name}--huge"] {
 			display: block;
 
 			&:first-child {

--- a/components/card/tag/tag.js
+++ b/components/card/tag/tag.js
@@ -1,11 +1,11 @@
 import React, {Component} from 'react';
-import {responsiveClass} from '../helpers';
+import {responsiveValue} from '../helpers';
 
 export default class Tag extends Component {
 	render () {
 		const tag = this.props.tag;
 		return (
-			<p className={'card__tag card__tag--' + tag.taxonomy + ' ' + responsiveClass('card__tag', this.props.size)}>
+			<p className={'card__tag card__tag--' + tag.taxonomy} data-size={responsiveValue(this.props.size)}>
 				<a className="card__tag__link" href={tag.url} data-trackable="primary-tag">
 					{tag.name}
 				</a>

--- a/components/card/title/main.scss
+++ b/components/card/title/main.scss
@@ -61,7 +61,6 @@ $card-title-text-sizes: (
 		huge: 44 46
 	)
 );
-$breakpoints: map-keys($card-title-text-sizes);
 
 @mixin card-title($text-size, $font-size, $line-height) {
 	font-size: $font-size + 0px;
@@ -91,34 +90,18 @@ $breakpoints: map-keys($card-title-text-sizes);
 	}
 }
 
-@each $breakpoint in $breakpoints {
+@each $breakpoint, $text-sizes in $card-title-text-sizes {
 	@if ($breakpoint == 'default') {
-		@each $cardBreakpoint, $text-sizes in $card-title-text-sizes {
-			@if ($cardBreakpoint == 'default') {
-				@each $text-size, $font-sizes in $text-sizes {
-					.card__title--#{$text-size} {
-						@include card-title($text-size, nth($font-sizes, 1), nth($font-sizes, 2));
-					}
-				}
-			} @else {
-				@include oGridRespondTo($cardBreakpoint) {
-					@each $text-size, $font-sizes in $text-sizes {
-						.card__title--#{$text-size} {
-							@include card-title($text-size, nth($font-sizes, 1), nth($font-sizes, 2));
-						}
-					}
-				}
+		@each $text-size, $font-sizes in $text-sizes {
+			.card__title[data-size~="#{$text-size}"] {
+				@include card-title($text-size, nth($font-sizes, 1), nth($font-sizes, 2));
 			}
 		}
 	} @else {
-		@each $cardBreakpoint, $text-sizes in $card-title-text-sizes {
-			@if (index($breakpoints, $cardBreakpoint) >= index($breakpoints, $breakpoint)) {
-				@include oGridRespondTo($cardBreakpoint) {
-					@each $text-size, $font-sizes in $text-sizes {
-						.card__title--#{$breakpoint}--#{$text-size} {
-							@include card-title($text-size, nth($font-sizes, 1), nth($font-sizes, 2));
-						}
-					}
+		@include oGridRespondTo($breakpoint) {
+			@each $text-size, $font-sizes in $text-sizes {
+				.card__title[data-size~="#{$breakpoint}--#{$text-size}"] {
+					@include card-title($text-size, nth($font-sizes, 1), nth($font-sizes, 2));
 				}
 			}
 		}

--- a/components/card/title/title.js
+++ b/components/card/title/title.js
@@ -3,7 +3,6 @@ import {responsiveValue} from '../helpers';
 
 export default class Title extends Component {
 	render () {
-		console.log(this.props.size);
 		return (
 			<h2 className="card__title" data-size={responsiveValue(this.props.size, true)}>
 				<a className="card__title-link" href={this.props.href} data-trackable="main-link">{this.props.title}</a>

--- a/components/card/title/title.js
+++ b/components/card/title/title.js
@@ -1,10 +1,11 @@
 import React, {Component} from 'react';
-import {responsiveClass} from '../helpers';
+import {responsiveValue} from '../helpers';
 
 export default class Title extends Component {
 	render () {
+		console.log(this.props.size);
 		return (
-			<h2 className={'card__title ' + responsiveClass('card__title', this.props.size)}>
+			<h2 className="card__title" data-size={responsiveValue(this.props.size, true)}>
 				<a className="card__title-link" href={this.props.href} data-trackable="main-link">{this.props.title}</a>
 			</h2>
 		);

--- a/components/card/title/title.js
+++ b/components/card/title/title.js
@@ -1,8 +1,18 @@
 import React, {Component} from 'react';
 import {responsiveValue} from '../helpers';
+import { layoutNames } from '../../layout/engine';
 
 export default class Title extends Component {
 	render () {
+		// need to have a size for all layout values, so need to fill it out up to XL
+		layoutNames.reduce((largestValue, layoutName) => {
+			if (!this.props.size[layoutName]) {
+				return this.props.size[layoutName] = largestValue;
+			} else {
+				return this.props.size[layoutName];
+			}
+		}, this.props.size.default);
+
 		return (
 			<h2 className="card__title" data-size={responsiveValue(this.props.size, true)}>
 				<a className="card__title-link" href={this.props.href} data-trackable="main-link">{this.props.title}</a>

--- a/components/card/video.js
+++ b/components/card/video.js
@@ -6,7 +6,7 @@ class Video extends Component {
 	render () {
 		const video = this.props.item;
 		return (
-			<article className="card card--stretch card--video" data-card-show={responsiveValue(this.props.show)}>
+			<article className="card card--stretch card--video" data-show={responsiveValue(this.props.show)}>
 				{/* wrapper needed for firefox */}
 				<div>
 					<div

--- a/components/card/video.js
+++ b/components/card/video.js
@@ -5,8 +5,15 @@ import {responsiveValue} from './helpers';
 class Video extends Component {
 	render () {
 		const video = this.props.item;
+		const showCard = responsiveValue(this.props.show);
+		const attrs = {
+			className: 'card card--stretch card--video'
+		};
+		if (showCard.includes('false')) {
+			Object.assign(attrs, { 'data-show': showCard });
+		}
 		return (
-			<article className="card card--stretch card--video" data-show={responsiveValue(this.props.show)}>
+			<article {...attrs}>
 				{/* wrapper needed for firefox */}
 				<div>
 					<div

--- a/config/layout.js
+++ b/config/layout.js
@@ -18,30 +18,30 @@ export default [
 		}),
 		cards: {
 			default: [
-				{ size: 'large', standFirst: true, image: true, related: 1 },
-				{ size: 'medium', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'tiny', landscape: true },
-				{ size: 'tiny', landscape: true },
-				{ size: 'tiny', image: true, landscape: true },
-				{ size: 'tiny', landscape: true }
+				{ column: 0, size: 'large', standFirst: true, image: true, related: 1 },
+				{ column: 0, size: 'medium', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 2, size: 'tiny', landscape: true },
+				{ column: 2, size: 'tiny', landscape: true },
+				{ column: 2, size: 'tiny', image: true, landscape: true },
+				{ column: 2, size: 'tiny', landscape: true }
 			],
 			S: [
-				{ size: 'large', standFirst: true, image: true, related: 3 },
-				{ size: 'medium', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'small', landscape: true },
-				{ size: 'tiny', landscape: true },
-				{ size: 'tiny', landscape: true },
-				{ size: 'tiny', image: true, landscape: true },
-				{ size: 'tiny', landscape: true }
+				{ column: 0, size: 'large', standFirst: true, image: true, related: 3 },
+				{ column: 0, size: 'medium', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 1, size: 'small', landscape: true },
+				{ column: 2, size: 'tiny', landscape: true },
+				{ column: 2, size: 'tiny', landscape: true },
+				{ column: 2, size: 'tiny', image: true, landscape: true },
+				{ column: 2, size: 'tiny', landscape: true }
 			],
 			M: [
 				{ column: 0, width: 5, size: 'large', standFirst: true, image: true, related: 3 },
@@ -110,24 +110,24 @@ export default [
 		}),
 		cards: {
 			default: [
-				{ size: 'medium', standFirst: true, image: true },
-				{ size: 'small' },
-				{ size: 'small', image: true, landscape: true },
-				{ size: 'small', image: true, landscape: true },
-				{ size: 'small' },
-				{ size: 'tiny' },
-				{ size: 'tiny', image: true, landscape: true },
-				{ size: 'tiny' }
+				{ column: 0, size: 'medium', standFirst: true, image: true },
+				{ column: 1, size: 'small' },
+				{ column: 1, size: 'small', image: true, landscape: true },
+				{ column: 2, size: 'small', image: true, landscape: true },
+				{ column: 2, size: 'small' },
+				{ column: 3, size: 'tiny' },
+				{ column: 3, size: 'tiny', image: true, landscape: true },
+				{ column: 3, size: 'tiny' }
 			],
 			S: [
-				{ size: 'medium', standFirst: true, image: true },
-				{ size: 'small' },
-				{ size: 'small', image: true, landscape: true },
-				{ size: 'small', image: true, landscape: true },
-				{ size: 'small' },
-				{ size: 'tiny' },
-				{ size: 'tiny', image: true, landscape: true },
-				{ size: 'tiny' }
+				{ column: 0, size: 'medium', standFirst: true, image: true },
+				{ column: 1, size: 'small' },
+				{ column: 1, size: 'small', image: true, landscape: true },
+				{ column: 2, size: 'small', image: true, landscape: true },
+				{ column: 2, size: 'small' },
+				{ column: 3, size: 'tiny' },
+				{ column: 3, size: 'tiny', image: true, landscape: true },
+				{ column: 3, size: 'tiny' }
 			],
 			M: [
 				{ column: 0, width: 3, size: 'medium', standFirst: true, image: true },
@@ -171,28 +171,28 @@ export default [
 		}),
 		cards: {
 			default: [
-				{ size: 'tiny', landscape: true, image: true, imageStick: true },
-				{ size: 'tiny', landscape: true, image: true, imageStick: true },
-				{ size: 'tiny', landscape: true, image: true, imageStick: true },
-				{ size: 'tiny', landscape: true, image: true, imageStick: true },
-				{ size: 'tiny', landscape: true, image: true, imageStick: true },
-				{ size: 'tiny', landscape: true, image: true, imageStick: true }
+				{ column: 0, size: 'tiny', landscape: true, image: true, imageStick: true },
+				{ column: 1, size: 'tiny', landscape: true, image: true, imageStick: true },
+				{ column: 2, size: 'tiny', landscape: true, image: true, imageStick: true },
+				{ column: 3, size: 'tiny', landscape: true, image: true, imageStick: true },
+				{ column: 4, size: 'tiny', landscape: true, image: true, imageStick: true },
+				{ column: 5, size: 'tiny', landscape: true, image: true, imageStick: true }
 			],
 			S: [
 				{ column: 0, width: 6, size: 'small', image: true, imageStick: true },
 				{ column: 1, width: 6, size: 'small', image: true, imageStick: true },
-				{ column: 0, width: 6, size: 'small', image: true, imageStick: true },
-				{ column: 1, width: 6, size: 'small', image: true, imageStick: true },
-				{ column: 0, width: 6, size: 'small', image: true, imageStick: true },
-				{ column: 1, width: 6, size: 'small', image: true, imageStick: true }
+				{ column: 2, width: 6, size: 'small', image: true, imageStick: true },
+				{ column: 3, width: 6, size: 'small', image: true, imageStick: true },
+				{ column: 4, width: 6, size: 'small', image: true, imageStick: true },
+				{ column: 5, width: 6, size: 'small', image: true, imageStick: true }
 			],
 			M: [
 				{ column: 0, width: 4, size: 'small', image: true, imageStick: true },
 				{ column: 1, width: 4, size: 'small', image: true, imageStick: true },
 				{ column: 2, width: 4, size: 'small', image: true, imageStick: true },
-				{ column: 0, width: 4, size: 'small', image: true, imageStick: true },
-				{ column: 1, width: 4, size: 'small', image: true, imageStick: true },
-				{ column: 2, width: 4, size: 'small', image: true, imageStick: true }
+				{ column: 3, width: 4, size: 'small', image: true, imageStick: true },
+				{ column: 4, width: 4, size: 'small', image: true, imageStick: true },
+				{ column: 5, width: 4, size: 'small', image: true, imageStick: true }
 			],
 			L: [
 				{ column: 0, width: 2, size: 'small', image: true, imageStick: true },
@@ -328,26 +328,26 @@ export default [
 		},
 		cards: {
 			default: [
-				{ size: 'medium', standFirst: true, image: true },
-				{ size: 'small' },
-				{ size: 'small', image: true, landscape: true },
-				{ size: 'small', image: true, landscape: true },
-				{ size: 'small' },
-				{ size: 'tiny' },
-				{ size: 'tiny' },
-				{ size: 'tiny' },
-				{ size: 'tiny' }
+				{ column: 0, size: 'medium', standFirst: true, image: true },
+				{ column: 1, size: 'small' },
+				{ column: 1, size: 'small', image: true, landscape: true },
+				{ column: 2, size: 'small', image: true, landscape: true },
+				{ column: 2, size: 'small' },
+				{ column: 3, size: 'tiny' },
+				{ column: 3, size: 'tiny' },
+				{ column: 3, size: 'tiny' },
+				{ column: 3, size: 'tiny' }
 			],
 			S: [
-				{ size: 'medium', standFirst: true, image: true },
-				{ size: 'small' },
-				{ size: 'small', image: true, landscape: true },
-				{ size: 'small', image: true, landscape: true },
-				{ size: 'small' },
-				{ size: 'tiny' },
-				{ size: 'tiny' },
-				{ size: 'tiny' },
-				{ size: 'tiny' }
+				{ column: 0, size: 'medium', standFirst: true, image: true },
+				{ column: 1, size: 'small' },
+				{ column: 1, size: 'small', image: true, landscape: true },
+				{ column: 2, size: 'small', image: true, landscape: true },
+				{ column: 2, size: 'small' },
+				{ column: 3, size: 'tiny' },
+				{ column: 3, size: 'tiny' },
+				{ column: 3, size: 'tiny' },
+				{ column: 3, size: 'tiny' }
 			],
 			M: [
 				{ column: 0, width: 3, size: 'medium', standFirst: true, image: true },
@@ -518,8 +518,8 @@ export default [
 			S: [
 				{ column: 0, width: 6 },
 				{ column: 1, width: 6 },
-				{ column: 0, width: 6 },
-				{ column: 1, width: 6 }
+				{ column: 2, width: 6 },
+				{ column: 3, width: 6 }
 			],
 			M: [
 				{ column: 0, width: 3 },

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -62,7 +62,7 @@ export default (region) => {
 			preconnect: [
 				'https://next-markets-proxy.ft.com'
 			],
-			minifyHtml: res.locals.flags.frontPageLayoutPrototype && res.locals.flags.frontPageMinifyHtml,
+			minifyHtml: res.locals.flags.frontPageMinifyHtml,
 			adsLayout: res.locals.flags.frontPageLayoutPrototype ? 'prototype': null
 		};
 		if (res.locals.flags.frontPageHeaderMarketsData) {

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -62,7 +62,7 @@ export default (region) => {
 			preconnect: [
 				'https://next-markets-proxy.ft.com'
 			],
-			minifyHtml: res.locals.flags.frontPageMinifyHtml,
+			minifyHtml: res.locals.flags.frontPageLayoutPrototype && res.locals.flags.frontPageMinifyHtml,
 			adsLayout: res.locals.flags.frontPageLayoutPrototype ? 'prototype': null
 		};
 		if (res.locals.flags.frontPageHeaderMarketsData) {

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -51,7 +51,7 @@
 		</div>
 	{{/if}}
 
-<!--
+<!--!
 
  FFFFFFFFFFFFFFFFFFFFFFTTTTTTTTTTTTTTTTTTTTTTT
  F::::::::::::::::::::FT:::::::::::::::::::::T


### PR DESCRIPTION
 * Tidied up the layout config, so there shouldn't be any 'hidden' cards.
 * Made a few assumptions to save on outputting attributes
   * if we never hide a card, omit `data-show`
   * if there is no primaryImage or we never hide the image, omit `data-image-show`
   * if we don't show the image or we never go landscape, omit `data-landscape`
 * Output all the sizes for the `card__title`; makes the css smaller and easier to write
 * Tell the minifier to keep the hidden graduate comment, means we can turn on html minification
 * Remove unused css

Also, as a general tidy, move the sizes into `data-` attributes, rather than classes, to make things more consistent (and smaller?)

### Before
 * HTML - 160Kb
 * CSS - 333Kb

### After (with HTML minification)
 * HTML - 103Kb (36%)
 * CSS - 319Kb (4%)