### PR TITLE
Check for presence of top stories before assuming graphQL response is OK

### DIFF
--- a/server/libs/graphql-poller.js
+++ b/server/libs/graphql-poller.js
@@ -2,34 +2,42 @@ import Poller from 'ft-poller';
 import queries from '../../config/queries';
 import { logger } from 'ft-next-logger';
 
+
 let queryResults = {
 	frontPageUK: {
 		data: null,
-		lastUpdated: null
+		lastUpdated: null,
+		isValid: (data) => data && data.top && data.top.items && data.top.items.length
 	},
 	frontPageUS: {
 		data: null,
-		lastUpdated: null
+		lastUpdated: null,
+		isValid: (data) => data && data.top && data.top.items && data.top.items.length
 	},
 	newFrontPageUK: {
 		data: null,
-		lastUpdated: null
+		lastUpdated: null,
+		isValid: (data) => data && data.top && data.top.items && data.top.items.length
 	},
 	newFrontPageUS: {
 		data: null,
-		lastUpdated: null
+		lastUpdated: null,
+		isValid: (data) => data && data.top && data.top.items && data.top.items.length
 	},
 	fastFT: {
 		data: null,
-		lastUpdated: null
+		lastUpdated: null,
+		isValid: (data) => data && data.fastFT && data.fastFT.items && data.fastFT.items.length
 	},
 	mockFrontPage: {
 		data: null,
-		lastUpdated: null
+		lastUpdated: null,
+		isValid: (data) => data && data.top && data.top.items && data.top.items.length
 	},
 	mockFrontPageNew: {
 		data: null,
-		lastUpdated: null
+		lastUpdated: null,
+		isValid: (data) => data && data.top && data.top.items && data.top.items.length
 	}
 };
 
@@ -50,7 +58,7 @@ const pollData = (query, name, flags = {}) => {
 			}
 		},
 		parseData: function (results) {
-			if(results && Object.keys(results).length) {
+			if(queryResults[name].isValid(results)) {
 				queryResults[name].data= results;
 				queryResults[name].lastUpdated = Date.now();
 			} else {


### PR DESCRIPTION
/cc @ironsidevsquincy @andygout @matthew-andrews 

Currently if CAPI is down, graphQL will still return results for videos (with all other keys being null).

This ensures that the poller doesn't overwrite the in-memory data if there are no top stories in the response.