### PR TITLE
Markets Data: correct labelling

### DIFF
--- a/client/components/markets-data/markets-data.js
+++ b/client/components/markets-data/markets-data.js
@@ -15,12 +15,12 @@ const regionalSecurities = {
 			type: 'indices'
 		},
 		{
-			name: 'Dollar/Euro',
+			name: 'Euro/Dollar',
 			symbol: 'EURUSD',
 			type: 'equities'
 		},
 		{
-			name: 'Dollar/Pound',
+			name: 'Pound/Dollar',
 			symbol: 'GBPUSD',
 			type: 'equities'
 		},
@@ -52,7 +52,7 @@ const regionalSecurities = {
 			type: 'indices'
 		},
 		{
-			name: 'Dollar/Euro',
+			name: 'Euro/Dollar',
 			symbol: 'EURUSD',
 			type: 'equities'
 		},


### PR DESCRIPTION
"ReportSomething : On the homepage at 18:02 GMT, the dollar/pound is shown as up 0.90%. Actually that should be labelled the pound/dollar pair."