### PR TITLE
Fix image position when with related items

### DIFF
--- a/config/layouts/opinion.js
+++ b/config/layouts/opinion.js
@@ -16,7 +16,7 @@ export default [
 						size: 'large',
 						showStandfirst: true,
 						image: {
-							srcSet: { default: 449, s: 659, m: 199, l: 259, xl: 322 }
+							srcSet: { default: 449, s: 659, m: 199, l: 357, xl: 430 }
 						}
 					}
 				]

--- a/shared/components/card/image/_image.scss
+++ b/shared/components/card/image/_image.scss
@@ -1,7 +1,6 @@
 .card__image-link {
 	@include displayFlex;
-
-	flex: 1 1 auto;
+	flex: 0 1 auto;
 	align-items: flex-start;
 	margin-top: 10px;
 	border-bottom: 0;
@@ -57,6 +56,7 @@
 
 .card__image-link--stick,
 .card__image-link--headshot {
+	flex-grow: 1;
 	align-items: flex-end;
 
 	.card[data-image-position~="left"] & {


### PR DESCRIPTION
Also, correct size of image in Opinion section

![screen shot 2016-02-03 at 11 36 07](https://cloud.githubusercontent.com/assets/74132/12781131/64bf85d0-ca6a-11e5-9339-2a35fcd5363e.jpeg)
