### PR TITLE
Ie10 image overflow

### DIFF
--- a/shared/components/ad/_ad.scss
+++ b/shared/components/ad/_ad.scss
@@ -5,3 +5,9 @@
 		margin-top: oGridGutter(M);
 	}
 }
+
+//Workaround for Chrome 48 jumping boxes bug https://code.google.com/p/chromium/issues/detail?id=546034#c6
+.ad-placeholder {
+	min-width: 0;
+	min-height: 0;
+}

--- a/shared/components/card/_card-ie8.scss
+++ b/shared/components/card/_card-ie8.scss
@@ -1,4 +1,5 @@
 @import 'image/image-ie8';
+@import 'title/title-ie8';
 
 @each $layout-name in $_o-grid-layout-names {
 	@include oGridTargetIE8 {

--- a/shared/components/card/_card.scss
+++ b/shared/components/card/_card.scss
@@ -9,6 +9,10 @@
 	line-height: 1;
 	flex: 1 1 auto;
 
+//Workaround for Chrome 48 jumping boxes bug https://code.google.com/p/chromium/issues/detail?id=546034#c6
+	min-height: 0;
+	min-width: 0;
+
 	@include oGridRespondTo(M) {
 		margin-top: oGridGutter(M);
 	}
@@ -96,6 +100,7 @@
 		}
 	}
 }
+
 
 @import 'article';
 @import 'concept';

--- a/shared/components/card/image/_image.scss
+++ b/shared/components/card/image/_image.scss
@@ -76,6 +76,11 @@
 	}
 }
 
+.card__picture {
+	display: block;
+	max-width: 100%;
+}
+
 .card__image {
 	display: block;
 	width: 100%;

--- a/shared/components/card/title/_title-ie8.scss
+++ b/shared/components/card/title/_title-ie8.scss
@@ -1,0 +1,21 @@
+.card__title {
+	@each $layout-name in $_o-grid-layout-names {
+		@include oGridTargetIE8 {
+
+			.card[data-image-position~="#{$layout-name}--bottom"] & {
+				min-height: 0;
+				margin-left: 0px;
+			}
+
+			.card[data-image-position~="#{$layout-name}--left"] & {
+				min-height: 56px;
+				margin-left: 110px;
+			}
+
+			.card[data-size="tiny"][data-image-position~="#{$layout-name}--left"] & {
+				min-height: 0;
+				margin-left: 0;
+			}
+		}
+	}
+}

--- a/shared/components/card/title/_title.scss
+++ b/shared/components/card/title/_title.scss
@@ -120,7 +120,6 @@ $card-title-text-sizes: (
 	border-bottom: 0;
 
 	&:hover {
-		text-decoration: underline;
-		text-decoration-style: dotted;
+		border-bottom: 1px dotted;
 	}
 }


### PR DESCRIPTION
* FIxes image overflowing out of their container in IE10
* Couple of IE8 layout fixes
* Workaround for the Chrome 48 jumpy bug (and bring back dotted underline)

@ironsidevsquincy 