### PR TITLE
Multiple Layouts: Landscape

### DIFF
--- a/config/layouts/index.js
+++ b/config/layouts/index.js
@@ -7,6 +7,8 @@ import myftLayout from './myft';
 import opinionLayout from './opinion';
 import topStoriesLayout from './top-stories';
 import topStoriesLandscapeLayout from './top-stories-landscape';
+import topStoriesPictureStoryLayout from './top-stories-picture-story';
+import topStoriesAssassinationLayout from './top-stories-assassination';
 import VideoLayout from './video';
 
 export default {
@@ -19,5 +21,7 @@ export default {
 	'opinion': opinionLayout,
 	'top-stories': topStoriesLayout,
 	'top-stories-landscape': topStoriesLandscapeLayout,
+	'top-stories-picture-story': topStoriesPictureStoryLayout,
+	'top-stories-assassination': topStoriesAssassinationLayout,
 	'video': VideoLayout
 }

--- a/config/layouts/top-stories-assassination.js
+++ b/config/layouts/top-stories-assassination.js
@@ -1,0 +1,159 @@
+import Row from '../../shared/components/row/row';
+import Column from '../../shared/components/column/column';
+import Content from '../../shared/components/content/content';
+
+export default [
+	{ type: Row,
+		components: [
+			{
+				type: Column,
+				colspan: { default: 12, XL: 9},
+				components: [
+					{
+						type: Row,
+						components: [
+							//Column 0
+							{
+								type: Column,
+								colspan: { default: 12 },
+								components: [
+									{
+										type: Content,
+										size: 'large-top-story',
+										showStandfirst: true,
+										related: {
+											show: true,
+											colspan: { default: 12, M: 4 }
+										},
+										image: {
+											sizes: { default: 449, s: 659, m: 432, l: 357, xl: 411 },
+											position: { default: 'right' }
+										}
+									}
+								]
+							}
+						]
+					},
+					{
+						type: Row,
+						components: [
+							//Column 0
+							{
+								type: Column,
+								colspan: { default: 12, M: 4 },
+								components: [
+									{
+										type: Content,
+										size: 'small',
+										image: {
+											sizes: { default: 449, s: 659, m: 432, l: 357, xl: 411 },
+											position: { default: 'top' }
+										}
+									}
+								]
+							},
+							//Column 1
+							{
+								type: Column,
+								colspan: { default: 12, M: 4 },
+								components: [
+									{
+										type: Content,
+										size: 'small',
+										showStandfirst: true
+									}
+								]
+							},
+								//Column 1
+							{
+								type: Column,
+								colspan: { default: 12, M: 4 },
+								components: [
+									{
+										type: Content,
+										size: 'small'
+									},
+									{
+										type: Content,
+										size: 'small'
+
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			{
+				type: Column,
+				condensed: true,
+				colspan: { default: 12, XL: 3 },
+				components: [
+					{
+						type: Row,
+						isCompact: true,
+						components:
+							[
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								}
+							]
+					}
+				]
+			}
+		]
+	}
+
+];

--- a/config/layouts/top-stories-landscape.js
+++ b/config/layouts/top-stories-landscape.js
@@ -3,65 +3,146 @@ import Column from '../../shared/components/column/column';
 import Content from '../../shared/components/content/content';
 
 export default [
-	{
-		type: Row,
+	{ type: Row,
 		components: [
-			//Column 0
 			{
 				type: Column,
-				colspan: { default: 12 },
+				colspan: { default: 12, XL: 9},
 				components: [
 					{
-						type: Content,
-						size: 'large',
-						showStandfirst: true,
-						image: {
-							sizes: { default: 449, s: 659, m: 432, l: 357, xl: 411 },
-							position: { default: 'right' }
-						}
-					}
-				]
-			}
-		]
-	},
-	{
-		type: Row,
-		components: [
-			//Column 0
-			{
-				type: Column,
-				colspan: { default: 12, M: 6 },
-				components: [
+						type: Row,
+						components: [
+							//Column 0
+							{
+								type: Column,
+								colspan: { default: 12 },
+								components: [
+									{
+										type: Content,
+										size: 'large-top-story',
+										showStandfirst: true,
+										related: {
+											show: true,
+											colspan: { default: 12, M: 4 }
+										},
+										image: {
+											sizes: { default: 449, s: 659, m: 432, l: 357, xl: 411 },
+											position: { default: 'right' }
+										}
+									}
+								]
+							}
+						]
+					},
 					{
-						type: Content,
-						size: 'large',
-						showStandfirst: true,
-						image: {
-							sizes: { default: 449, s: 659, m: 432, l: 357, xl: 411 },
-							position: { default: 'top' }
-						}
+						type: Row,
+						components: [
+							//Column 0
+							{
+								type: Column,
+								colspan: { default: 12, M: 4 },
+								components: [
+									{
+										type: Content,
+										size: 'small',
+										image: {
+											sizes: { default: 449, s: 659, m: 432, l: 357, xl: 411 },
+											position: { default: 'top' }
+										}
+									}
+								]
+							},
+							//Column 1
+							{
+								type: Column,
+								colspan: { default: 12, M: 4 },
+								components: [
+									{
+										type: Content,
+										size: 'small',
+										showStandfirst: true
+									}
+								]
+							},
+								//Column 1
+							{
+								type: Column,
+								colspan: { default: 12, M: 4 },
+								components: [
+									{
+										type: Content,
+										size: 'small'
+									},
+									{
+										type: Content,
+										size: 'small'
+
+									}
+								]
+							}
+						]
 					}
 				]
 			},
-			//Column 1
 			{
 				type: Column,
-				colspan: { default: 12, M: 6 },
+				condensed: true,
+				colspan: { default: 12, XL: 3 },
 				components: [
 					{
-						type: Content,
-						size: 'medium'
-					},
-					{
-						type: Content,
-						size: 'medium',
-						image: {
-							sizes: { default: 100 },
-							position: { default: 'left' }
-						}
+						type: Row,
+						isCompact: true,
+						components:
+							[
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'small',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'small',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'small',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'small',
+											hideTag: true
+										}
+									]
+								}
+							]
 					}
 				]
 			}
 		]
 	}
+
 ];

--- a/config/layouts/top-stories-landscape.js
+++ b/config/layouts/top-stories-landscape.js
@@ -100,7 +100,7 @@ export default [
 									components: [
 										{
 											type: Content,
-											size: 'small',
+											size: 'tiny',
 											hideTag: true
 										}
 									]
@@ -111,7 +111,7 @@ export default [
 									components: [
 										{
 											type: Content,
-											size: 'small',
+											size: 'tiny',
 											hideTag: true
 										}
 									]
@@ -122,7 +122,7 @@ export default [
 									components: [
 										{
 											type: Content,
-											size: 'small',
+											size: 'tiny',
 											hideTag: true
 										}
 									]
@@ -133,7 +133,18 @@ export default [
 									components: [
 										{
 											type: Content,
-											size: 'small',
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
 											hideTag: true
 										}
 									]

--- a/config/layouts/top-stories-picture-story.js
+++ b/config/layouts/top-stories-picture-story.js
@@ -1,0 +1,131 @@
+import Row from '../../shared/components/row/row';
+import Column from '../../shared/components/column/column';
+import Content from '../../shared/components/content/content';
+
+export default [
+	{
+		type: Row,
+		components: [
+			//Column 0
+			{
+				type: Column,
+				colspan: { default: 12, M: 6, XL: 5 },
+				components: [
+					{
+						type: Content,
+						size: 'large-top-story',
+						related: {
+							show: true,
+							colspan: { default: 12}
+						},
+						showRelated: true,
+						showStandfirst: true,
+						image: {
+							sizes: { default: 449, s: 659, m: 432, l: 357, xl: 411 }
+						}
+					}
+				]
+			},
+			//Column 1
+			{
+				type: Column,
+				colspan: { default: 12, M: 6, XL: 5 },
+				components: [
+					{
+						type: Content,
+						size: 'medium',
+						showStandfirst: true,
+						image: {
+							sizes: { default: 100 },
+							position: { default: 'left' }
+						}
+					},
+					{
+						type: Content,
+						size: 'medium',
+						showStandfirst: true
+					},
+					{
+						type: Content,
+						size: 'medium'
+					},
+					{
+						type: Content,
+						size: 'medium'
+					}
+				]
+			},
+			//Column 2
+			{
+				type: Column,
+				condensed: true,
+				colspan: { default: 12, XL: 2 },
+				components: [
+					{
+						type: Row,
+						isCompact: true,
+						components:
+							[
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true
+										}
+									]
+								},
+								{
+									type: Column,
+									colspan: { default: 12, M: 3, XL: 12 },
+									components: [
+										{
+											type: Content,
+											size: 'tiny',
+											hideTag: true,
+											show: { default: false, XL: true }
+										}
+									]
+								}
+							]
+					}
+				]
+			}
+		]
+	}
+];

--- a/config/layouts/top-stories.js
+++ b/config/layouts/top-stories.js
@@ -14,6 +14,10 @@ export default [
 					{
 						type: Content,
 						size: 'large-top-story',
+						related: {
+							show: true,
+							colspan: { default: 12}
+						},
 						showRelated: true,
 						showStandfirst: true,
 						image: {

--- a/config/queries.js
+++ b/config/queries.js
@@ -104,6 +104,22 @@ const frontPage = (region) => (`
 				}
 			}
 		}
+		topStoriesList(region: ${region}) {
+			layoutHint
+			items {
+				... Basic
+				... Extended
+				... Related
+				... on LiveBlog {
+					status
+					updates(limit: 1) {
+						date
+						text
+					}
+				}
+			}
+		}
+		
 		fastFT {
 			items(limit: 20) {
 				... Basic

--- a/config/sections/top-stories.js
+++ b/config/sections/top-stories.js
@@ -4,13 +4,32 @@ import FastFt from '../../shared/components/fast-ft/fast-ft';
 
 const date = dateFormat(new Date(), 'EEEE MMMM yyyy');
 
-export default () => ({
+const getLayout = (content, flags) => {
+	const layoutHint = content.layoutHint;
+
+	if(flags.frontPageMultipleLayouts) {
+		switch(layoutHint) {
+			case 'standaloneimage':
+				return 'top-stories-picture-story';
+			case 'landscape':
+				return 'top-stories-landscape';
+			case 'assassination':
+				return 'top-stories-assassination';
+			case 'standard':
+			default:
+				return 'top-stories';
+		}
+	} else {
+		return 'top-stories';
+	}
+};
+export default ({ content, flags }) => ({
 	id: 'top-stories',
 	title: 'Top Stories',
 	style: 'top-stories',
 	date: date,
 	isTab: true,
-	layoutId: 'top-stories',
+	layoutId: getLayout(content, flags),
 	size: {
 		default: 12
 	},

--- a/server/libs/section-content.js
+++ b/server/libs/section-content.js
@@ -1,11 +1,29 @@
 /**
  * take data from graphql and massage it into a format needed by the sections
  */
-export default data => ({
-	['top-stories']: {
-		main: data.frontPage.topStory.items.concat(data.frontPage.top.items.slice(1)),
+
+const getTopStoriesData = (data, flags) => {
+	let main = data.frontPage.topStory.items.concat(data.frontPage.top.items.slice(1));
+	const layoutHint = data.frontPage.topStoriesList.layoutHint;
+	if(flags.frontPageMultipleLayouts && layoutHint === 'standaloneimage') {
+		if(data.frontPage.topStoriesList && data.frontPage.topStoriesList.items && data.frontPage.topStoriesList.items.length) {
+			//Picture stories don't come through the page API, so if we have one, take it from the list and put it in the second positio
+			main.splice(1, 0, data.frontPage.topStoriesList.items[0]);
+		} else {
+			//No picture story available, so default to normal layout
+			layoutHint = 'standard';
+		}
+	}
+	return {
+		layoutHint,
+		main,
 		sidebar: data.frontPage.fastFT.items
-	},
+	}
+
+};
+
+export default (data, flags) => ({
+	['top-stories']: getTopStoriesData(data, flags),
 	opinion: {
 		main: data.frontPage.opinion.items
 	},

--- a/server/libs/section-content.js
+++ b/server/libs/section-content.js
@@ -2,10 +2,10 @@
  * take data from graphql and massage it into a format needed by the sections
  */
 
-const getTopStoriesData = (data, flags) => {
+const getTopStoriesData = (data, flags = {}) => {
 	let main = data.frontPage.topStory.items.concat(data.frontPage.top.items.slice(1));
-	const layoutHint = data.frontPage.topStoriesList.layoutHint;
-	if(flags.frontPageMultipleLayouts && layoutHint === 'standaloneimage') {
+	let layoutHint = flags.frontPageMultipleLayouts ? data.frontPage.topStoriesList.layoutHint : 'standard';
+	if(flags && flags.frontPageMultipleLayouts && layoutHint === 'standaloneimage') {
 		if(data.frontPage.topStoriesList && data.frontPage.topStoriesList.items && data.frontPage.topStoriesList.items.length) {
 			//Picture stories don't come through the page API, so if we have one, take it from the list and put it in the second positio
 			main.splice(1, 0, data.frontPage.topStoriesList.items[0]);
@@ -15,7 +15,7 @@ const getTopStoriesData = (data, flags) => {
 		}
 	}
 	return {
-		layoutHint,
+		layoutHint: layoutHint || 'standard',
 		main,
 		sidebar: data.frontPage.fastFT.items
 	}

--- a/server/routes/front-page.js
+++ b/server/routes/front-page.js
@@ -44,7 +44,7 @@ export default (region) => {
 			inside: '<p class="markets-data-disclaimer">Markets data delayed by at least 15 minutes</p>'
 		};
 
-		const sections = getPage('front-page', sectionContent(data), res.locals.flags);
+		const sections = getPage('front-page', sectionContent(data, res.locals.flags), res.locals.flags);
 
 		const renderParams = {
 			layout: 'wrapper',

--- a/shared/components/card/article.js
+++ b/shared/components/card/article.js
@@ -88,7 +88,7 @@ export default class extends Component {
 						{this.props.lastPublished ? <Timestamp date={this.props.lastPublished} /> : null}
 					</div>
 				</div>
-				{this.props.related ? <Related items={this.props.related} /> : null}
+				{this.props.related && this.props.related.content ? <Related {...this.props.related} /> : null}
 				{this.props.liveBlog ? <LiveBlogGlow {...this.props.liveBlog} /> : null}
 			</article>
 		);

--- a/shared/components/card/related/_related.scss
+++ b/shared/components/card/related/_related.scss
@@ -8,10 +8,10 @@
 	position: relative;
 	font-family: $o-typography-sans;
 	font-weight: oFontsWeight(light);
-	font-size: 18px;
-	line-height: 20px;
+	font-size: 16px;
+	line-height: 18px;
 	margin-top: 5px;
-	padding-left: 15px;
+	padding: 0 15px;
 }
 
 .card__related-item__link {

--- a/shared/components/card/related/_related.scss
+++ b/shared/components/card/related/_related.scss
@@ -6,8 +6,7 @@
 
 .card__related-item {
 	position: relative;
-	font-family: $o-typography-sans;
-	font-weight: oFontsWeight(light);
+	font-family: $o-typography-serif-display;
 	font-size: 16px;
 	line-height: 18px;
 	margin-top: 5px;

--- a/shared/components/card/related/related.js
+++ b/shared/components/card/related/related.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import colspanToString from '../../../../client/utils/colspan';
 
 /**
  * @param {Object[]) items
@@ -7,9 +8,9 @@ import React, {Component} from 'react';
  */
 export default class extends Component {
 	render () {
-		const relatedEls = this.props.items.map(item =>
-			<li className="card__related-item" key={item.id}>
-				<a href={`/content/${item.id}`} className="card__related-item__link" data-trackable="related">
+		const relatedEls = this.props.content.map(item =>
+			<li className="card__related-item" key={item.id} data-o-grid-colspan={colspanToString(this.props.colspan)}>
+				<a href={`/content/${item.id}`} className="card__related-item__link" data-trackable="related" >
 					{item.title}
 				</a>
 			</li>

--- a/shared/components/content/content.js
+++ b/shared/components/content/content.js
@@ -66,11 +66,13 @@ const getData = (item, opts) => {
 		if (!opts.hideTag && item.primaryTag) {
 			data.tag = item.primaryTag;
 		}
-		if (opts.showRelated) {
-			data.related = item.relatedContent
+		if (opts.related && opts.related.show) {
+			data.related = Object.assign({
+				content: item.relatedContent
 				.concat((item.primaryTag && item.primaryTag.items) || [])
 				.filter(relatedItem => relatedItem.id !== item.id)
-				.slice(0, 3);
+				.slice(0, 3)
+			}, opts.related);
 		}
 
 		if (item.contentType === 'LiveBlog') {

--- a/test/server/libs/section-content.test.js
+++ b/test/server/libs/section-content.test.js
@@ -1,0 +1,96 @@
+import chai from 'chai';
+import sectionContent from '../../../server/libs/section-content';
+
+const expect = chai.expect;
+
+describe ("Top stories data", () => {
+
+	const data = {
+		top: { items: ['1', '2', '3'] },
+		topStory: { items: ['1-with-more-stuff'] },
+		topStoriesList: { layoutHint: 'standard', items: [] },
+		fastFT: { items: ['a'] },
+		opinion: { items: ['a'] },
+		editorsPicks: { items: ['a'] },
+		popularTopics: ['a'],
+		popularArticles: ['a'],
+		technology: { items: ['a'] },
+		markets: { items: ['a'] },
+		lifestyle: { items: ['a'] },
+		videos: { items: ['a'] }
+	};
+
+	it('Takes top story and combines it with the other top stories', () => {
+		const results = sectionContent( {frontPage: data });
+		
+		expect(results['top-stories'].main.length).to.equal(3);
+		expect(results['top-stories'].main[0]).to.equal('1-with-more-stuff');
+		expect(results['top-stories'].main[2]).to.equal('3');
+		 
+	});
+	
+	it('uses standard layout if frontPageMultipleLayouts flag is off', () => {
+		data.topStoriesList = { items: ['list-1'], layoutHint: 'assassination' };
+		const results = sectionContent( {frontPage: data }, { frontPageMultipleLayouts: false });
+		
+		expect(results['top-stories'].layoutHint).to.equal('standard');
+	});
+	
+	it('uses editorial layout if frontPageMultipleLayouts flag is on', () => {
+		data.topStoriesList = { items: ['list-1'], layoutHint: 'assassination' };
+		const results = sectionContent( {frontPage: data }, { frontPageMultipleLayouts: true });
+
+		expect(results['top-stories'].layoutHint).to.equal('assassination');
+	});
+		
+	it('Does not include picture story from list if picture story layout chosen and flag is off', () => {
+		data.topStoriesList = { items: ['picture-story'], layoutHint: 'standaloneimage' };
+		const results = sectionContent( {frontPage: data }, { frontPageMultipleLayouts: false});
+		
+		expect(results['top-stories'].layoutHint).to.equal('standard');
+		
+		expect(results['top-stories'].main.length).to.equal(3);
+		expect(results['top-stories'].main[0]).to.equal('1-with-more-stuff');
+		expect(results['top-stories'].main[1]).to.equal('2');
+		expect(results['top-stories'].main[2]).to.equal('3');
+		 
+	});
+
+	it('Includes picture story from list if picture story layout chosen and flag is on', () => {
+		data.topStoriesList = { items: ['picture-story'], layoutHint: 'standaloneimage' };
+		const results = sectionContent( {frontPage: data }, { frontPageMultipleLayouts: true});
+		
+		expect(results['top-stories'].layoutHint).to.equal('standaloneimage');
+		
+		expect(results['top-stories'].main.length).to.equal(4);
+		expect(results['top-stories'].main[0]).to.equal('1-with-more-stuff');
+		expect(results['top-stories'].main[1]).to.equal('picture-story');
+		expect(results['top-stories'].main[3]).to.equal('3');
+		 
+	});
+
+	it('Defaults to standard layout if no picture story provided in list', () => {
+		data.topStoriesList = { items: [], layoutHint: 'standaloneimage' };
+		const results = sectionContent( {frontPage: data }, { frontPageMultipleLayouts: true});
+		
+		expect(results['top-stories'].layoutHint).to.equal('standard');
+		
+		expect(results['top-stories'].main.length).to.equal(3);
+		expect(results['top-stories'].main[0]).to.equal('1-with-more-stuff');
+		expect(results['top-stories'].main[1]).to.equal('2');
+		expect(results['top-stories'].main[2]).to.equal('3');
+	});
+
+	it('Defaults to standard layout if top stories list has no data', () => {
+		data.topStoriesList = { items: null, layoutHint: null };
+		const results = sectionContent( {frontPage: data }, { frontPageMultipleLayouts: true});
+		
+		expect(results['top-stories'].layoutHint).to.equal('standard');
+		
+		expect(results['top-stories'].main.length).to.equal(3);
+		expect(results['top-stories'].main[0]).to.equal('1-with-more-stuff');
+		expect(results['top-stories'].main[1]).to.equal('2');
+		expect(results['top-stories'].main[2]).to.equal('3');
+	});
+
+});

--- a/test/server/routes/front-page.test.js
+++ b/test/server/routes/front-page.test.js
@@ -36,6 +36,7 @@ describe('Front Page Controller', () => {
 		sinon.stub(poller, 'getData', () => ({
 			top: { items: ['a', 'b'] },
 			topStory: { items: ['a'] },
+			topStoriesList: { layoutHint: 'standard', items: [] },
 			fastFT: { items: ['a'] },
 			opinion: { items: ['a'] },
 			editorsPicks: { items: ['a'] },
@@ -59,6 +60,7 @@ describe('Front Page Controller', () => {
 		sinon.stub(poller, 'getData', () => ({
 			top: { items: ['a', 'b'] },
 			topStory: { items: [] },
+			topStoriesList: { layoutHint: null, items: [] },
 			fastFT: { items: ['a'] },
 			opinion: { items: ['a'] },
 			editorsPicks: { items: ['a'] },
@@ -77,6 +79,7 @@ describe('Front Page Controller', () => {
 		sinon.stub(poller, 'getData', () => ({
 			top: { items: [] },
 			topStory: { items: ['a'] },
+			topStoriesList: { layoutHint: null, items: [] },
 			fastFT: { items: ['a'] },
 			opinion: { items: ['a'] },
 			editorsPicks: { items: ['a'] },
@@ -95,6 +98,7 @@ describe('Front Page Controller', () => {
 		sinon.stub(poller, 'getData', () => ({
 			top: null,
 			topStory: { },
+			topStoriesList: { layoutHint: null, items: ['a'] },
 			fastFT: { items: ['a'] },
 			opinion: { items: ['a'] },
 			editorsPicks: { items: ['a'] },
@@ -114,6 +118,7 @@ describe('Front Page Controller', () => {
 		sinon.stub(poller, 'getData', () => ({
 			top: { items : ['a'] },
 			topStory: { items : ['a'] },
+			topStoriesList: { layoutHint: null, items: [] },
 			fastFT: { items: ['a'] },
 			opinion: { items: ['a'] },
 			editorsPicks: { items: ['a'] },


### PR DESCRIPTION
/cc @ironsidevsquincy @andygout 

Introduce the landscape layout behind a flag. 
Also adds other layouts (currently picture story is a copy of default, assassination is a copy of landscape).

* Related items can now have a colspan
* Slight font changes to related items (will affect all layouts)

<img width="1263" alt="screen shot 2016-02-10 at 16 59 27" src="https://cloud.githubusercontent.com/assets/1978880/12954726/b1c93ab2-d017-11e5-81d2-4178cb945c0c.png">