### PR TITLE
Tracking of multiple layouts

### DIFF
--- a/config/sections/top-stories.js
+++ b/config/sections/top-stories.js
@@ -30,6 +30,7 @@ export default ({ content, flags }) => ({
 	date: date,
 	isTab: true,
 	layoutId: getLayout(content, flags),
+	trackable: getLayout(content, flags),
 	size: {
 		default: 12
 	},


### PR DESCRIPTION
/cc @ironsidevsquincy @andygout 

Not sure if there's a better way to do this. Beacon aggregate graphs can then be 'starts with/contains top-stories'