### PR TITLE
Most popular size fix

### DIFF
--- a/config/layouts/most-popular-ads.js
+++ b/config/layouts/most-popular-ads.js
@@ -37,12 +37,17 @@ export default [
 						type: Content,
 						size: 'medium',
 						itemIndex: 1,
-						show: { default: false, M: true, L: false, XL: true },
+						show: { default: false, M: true, L: false },
 						image: {
-							show: { default: true, L: false },
 							position: { default: 'left', M: 'bottom' },
 							sizes: { default: 449, s: 659, m: 199, l: 259, xl: 322 }
 						}
+					},
+					{
+						type: Content,
+						size: 'medium',
+						itemIndex: 1,
+						show: { default: false, XL: true },
 					},
 					{
 						type: Content,

--- a/config/sections/top-stories.js
+++ b/config/sections/top-stories.js
@@ -30,6 +30,7 @@ export default ({ content, flags }) => ({
 	date: date,
 	isTab: true,
 	layoutId: getLayout(content, flags),
+	trackable: getLayout(content, flags),
 	size: {
 		default: 12
 	},

--- a/shared/components/card/article.js
+++ b/shared/components/card/article.js
@@ -21,7 +21,6 @@ import Timestamp from './timestamp/timestamp';
  * @param {Object} [image]
  * @param {string} image.url
  * @param {string} image.sizes
- * @param {string} [image.show]
  * @param {string} [image.position]
  * @param {Object} [liveBlog]
  * @param {string} liveBlog.status
@@ -41,9 +40,6 @@ export default class extends Component {
 		}
 
 		if (this.props.image) {
-			if (this.props.image.show) {
-				attrs['data-image-show'] = responsiveValue(this.props.image.show);
-			}
 			if (this.props.image.position) {
 				attrs['data-image-position'] = responsiveValue(this.props.image.position);
 			}


### PR DESCRIPTION
/cc @andygout @ironsidevsquincy 

The huge most popular card was because that card shows and hides it's image on different breakpoints. 

Rather than try and fix that CSS (with the padding) which would be massively complicated, just duplicate the card for now, one with an image and one without. This means we can get rid of the image.show property.

Hopefully the most popular section simplifies itself soon, so we can ditch all those complications.