### PR TITLE
Amend: Top stories landscape layout (stories 2-5 match picture story layout)

### DIFF
--- a/config/layouts/top-stories-landscape.js
+++ b/config/layouts/top-stories-landscape.js
@@ -59,24 +59,26 @@ export default [
 								components: [
 									{
 										type: Content,
-										size: 'medium',
-										showStandfirst: true
+										size: 'medium'
+									},
+									{
+										type: Content,
+										size: 'medium'
 									}
 								]
 							},
-								//Column 1
+							//Column 2
 							{
 								type: Column,
 								colspan: { default: 12, M: 4 },
 								components: [
 									{
 										type: Content,
-										size: 'medium'
-									},
-									{
-										type: Content,
-										size: 'medium'
-
+										size: 'medium',
+										image: {
+											sizes: { default: 100, s: 100, m: 277, l: 226, xl: 233 },
+											position: { default: 'left', M: 'top' }
+										}
 									}
 								]
 							}

--- a/shared/components/card/related/_related.scss
+++ b/shared/components/card/related/_related.scss
@@ -1,6 +1,6 @@
 .card__related-items {
 	margin: 5px 0 0;
-	padding: 0;
+	padding: 0 0 10px;
 	list-style-type: none;
 
 	&[data-show~="false"] {


### PR DESCRIPTION
cc @adgad @ironsidevsquincy 

N.B. Story 5 is current a story without a picture, but will display image same as story 2.

![screen shot 2016-02-12 at 15 45 22](https://cloud.githubusercontent.com/assets/10484515/13011998/4b4e226c-d1a1-11e5-9d7a-819bde3855c8.png)
