### PR TITLE
Modify: Top stories 'picture story' layout (picture story: remove tag; shade pink-tint1)

### DIFF
--- a/config/layouts/top-stories-picture-story.js
+++ b/config/layouts/top-stories-picture-story.js
@@ -37,6 +37,8 @@ export default [
 									{
 										type: Content,
 										size: 'medium',
+										hideTag: true,
+										isPictureStory: true,
 										image: {
 											position: { default: 'right', S: 'top' },
 											sizes: { default: 225, s: 315, m: 432, l: 357, xl: 366 }

--- a/shared/components/card/_article.scss
+++ b/shared/components/card/_article.scss
@@ -52,7 +52,7 @@
 }
 
 .card--picture-story {
-	background-color: oColorsGetPaletteColor('pink-tint1');
+	background-color: getColor('pink-tint1');
 }
 
 .liveblog__badge {

--- a/shared/components/card/_article.scss
+++ b/shared/components/card/_article.scss
@@ -52,7 +52,7 @@
 }
 
 .card--picture-story {
-	background-color: getColor('pink-tint1');
+	background-color: getColor('pink-tint3');
 }
 
 .liveblog__badge {

--- a/shared/components/card/_article.scss
+++ b/shared/components/card/_article.scss
@@ -51,6 +51,10 @@
 	}
 }
 
+.card--picture-story {
+	background-color: oColorsGetPaletteColor('pink-tint1');
+}
+
 .liveblog__badge {
 	@include oTypographySansBold(s);
 	display: inline-block;

--- a/shared/components/card/article.js
+++ b/shared/components/card/article.js
@@ -67,6 +67,10 @@ export default class extends Component {
 			attrs.className += ` card--transparent`;
 		}
 
+		if (this.props.isPictureStory) {
+			attrs.className += ` card--picture-story`;
+		}
+
 		return (
 			<article {...attrs}>
 				<div className={articleContentClasses.join(' ')}>

--- a/shared/components/content/content.js
+++ b/shared/components/content/content.js
@@ -63,6 +63,9 @@ const getData = (item, opts) => {
 		if (opts.showStandfirst) {
 			data.standfirst = item.summary;
 		}
+		if (opts.isPictureStory) {
+			data.isPictureStory = opts.isPictureStory;
+		}
 		if (!opts.hideTag && item.primaryTag) {
 			data.tag = item.primaryTag;
 		}


### PR DESCRIPTION
cc @ironsidevsquincy 

'Picture Story' layout: Picture story has tag removed and card background given darker shade.

#### L-XL
![l-xl](https://cloud.githubusercontent.com/assets/10484515/13044469/410da5e4-d3c6-11e5-8db4-e2e97164672c.png)

#### M
![m](https://cloud.githubusercontent.com/assets/10484515/13044471/43c9af4e-d3c6-11e5-87f6-a36fbfd637c8.png)

#### S
![s](https://cloud.githubusercontent.com/assets/10484515/13044481/4f57a4c4-d3c6-11e5-884a-f9b31624f5d5.png)

#### Default
![default](https://cloud.githubusercontent.com/assets/10484515/13044490/58ed5f56-d3c6-11e5-8e36-8bfa18549d36.png)