### PR TITLE
Dedupe stories in sections

### DIFF
--- a/config/queries.js
+++ b/config/queries.js
@@ -11,10 +11,12 @@ const fragments = `
 		primaryTag {
 			url
 			name
+			taxonomy
 		}
 		branding {
 			url
 			name
+			taxonomy
 		}
 		primaryImage {
 			rawSrc
@@ -112,7 +114,6 @@ const frontPage = (region) => (`
 				... Related
 				branding {
 					headshot
-					taxonomy
 				}
 			}
 		}

--- a/server/libs/section-content.js
+++ b/server/libs/section-content.js
@@ -2,7 +2,7 @@
  * take data from graphql and massage it into a format needed by the sections
  */
 
-const dedupe = (item, index, items) => items.findIndex(otherItem => otherItem.id === item.id) === index;
+const dedupe = (item, index, items) => !item.id || items.findIndex(otherItem => otherItem.id === item.id) === index;
 
 const getTopStoriesData = (data, flags = {}) => {
 	let main = data.frontPage.topStory.items.concat(data.frontPage.top.items.slice(1));

--- a/server/libs/section-content.js
+++ b/server/libs/section-content.js
@@ -2,6 +2,8 @@
  * take data from graphql and massage it into a format needed by the sections
  */
 
+const dedupe = (item, index, items) => items.findIndex(otherItem => otherItem.id === item.id) === index;
+
 const getTopStoriesData = (data, flags = {}) => {
 	let main = data.frontPage.topStory.items.concat(data.frontPage.top.items.slice(1));
 	let layoutHint = flags.frontPageMultipleLayouts ? data.frontPage.topStoriesList.layoutHint : 'standard';
@@ -26,6 +28,8 @@ const getTopStoriesData = (data, flags = {}) => {
 			layoutHint = 'standard';
 		}
 	}
+	// NOTE: only needed while maintaining both a list and a page, but dedupe
+	main = main.filter(dedupe);
 	return {
 		layoutHint,
 		main,

--- a/shared/components/card/related/_related.scss
+++ b/shared/components/card/related/_related.scss
@@ -41,14 +41,14 @@
 		font-size: 20px;
 		line-height: 22px;
 
-		@include oGridRespondTo(S) {
-			font-size: 22px;
-			line-height: 24px;
+		@include oGridRespondTo(M) {
+			font-size: 18px;
+			line-height: 20px;
 		}
 
-		@include oGridRespondTo(M) {
-			font-size: 24px;
-			line-height: 26px;
+		@include oGridRespondTo(L) {
+			font-size: 20px;
+			line-height: 24px;
 		}
 	}
 }

--- a/shared/components/card/tag/_tag.scss
+++ b/shared/components/card/tag/_tag.scss
@@ -51,6 +51,10 @@
 			@include nextIcon(pullquote, getColor('cold-1'), 16, $icon-only: true);
 		}
 	}
+
+	.card--main & {
+		padding-right: 10px;
+	}
 }
 
 .card__tag__follow {


### PR DESCRIPTION
While editorial are maintaining both a page and list for the top stories block, there will be duplication between the two. As an interim, dedupe stories