### PR TITLE
Track scroll depth

### DIFF
--- a/client/components/scroll-depth/scroll-depth.js
+++ b/client/components/scroll-depth/scroll-depth.js
@@ -1,12 +1,10 @@
 import fireTracking from '../../utils/fire-tracking';
 import throttle from '../../utils/throttle';
-import getDomPath from 'n-instrumentation/src/utils/getDomPath';
 
 const toArray = nodeList => Array.prototype.slice.call(nodeList);
 
-const track = (componentEl, componentPos) => {
-	const domPathTokens = getDomPath(componentEl, []);
-	fireTracking('oTracking.event', { category: 'page', action: 'scrolldepth', componentPos, domPathTokens: domPathTokens, domPath: domPathTokens.join(' | ') });
+const track = (dataTrackable, componentPos) => {
+	fireTracking('oTracking.event', { category: 'page', action: 'scrolldepth', dataTrackable, componentPos });
 }
 
 const scrollHandlerFactory = () => {
@@ -14,10 +12,10 @@ const scrollHandlerFactory = () => {
 	return () => {
 		toArray(document.querySelectorAll('.js-track-scroll-event'))
 			.forEach((component, index) => {
-				const componentId = component.getAttribute('data-trackable');
-				if (component.getBoundingClientRect().top < window.innerHeight && componentsViewed.indexOf(componentId) === -1) {
-					track(component, index + 1);
-					componentsViewed.push(componentId);
+				const dataTrackable = component.getAttribute('data-trackable');
+				if (component.getBoundingClientRect().top < window.innerHeight && componentsViewed.indexOf(dataTrackable) === -1) {
+					track(dataTrackable, index + 1);
+					componentsViewed.push(dataTrackable);
 				}
 			});
 	};

--- a/client/components/scroll-depth/scroll-depth.js
+++ b/client/components/scroll-depth/scroll-depth.js
@@ -4,13 +4,15 @@ import getDomPath from 'n-instrumentation/src/utils/getDomPath';
 
 const toArray = nodeList => Array.prototype.slice.call(nodeList);
 
-const track = (componentEl, componentPos) =>
-	fireTracking('oTracking.event', { category: 'page', action: 'scrolldepth', componentPos, domPath: getDomPath(componentEl, []) });
+const track = (componentEl, componentPos) => {
+	const domPathTokens = getDomPath(componentEl, []);
+	fireTracking('oTracking.event', { category: 'page', action: 'scrolldepth', componentPos, domPathTokens: domPathTokens, domPath: domPathTokens.join(' | ') });
+}
 
 const scrollHandlerFactory = () => {
 	const componentsViewed = [];
 	return () => {
-		toArray(document.querySelectorAll('.section'))
+		toArray(document.querySelectorAll('.js-track-scroll-event'))
 			.forEach((component, index) => {
 				const componentId = component.getAttribute('data-trackable');
 				if (component.getBoundingClientRect().top < window.innerHeight && componentsViewed.indexOf(componentId) === -1) {

--- a/client/components/scroll-depth/scroll-depth.js
+++ b/client/components/scroll-depth/scroll-depth.js
@@ -3,8 +3,8 @@ import throttle from '../../utils/throttle';
 
 const toArray = nodeList => Array.prototype.slice.call(nodeList);
 
-const track = (dataTrackable, componentPos) => {
-	fireTracking('oTracking.event', { category: 'page', action: 'scrolldepth', dataTrackable, componentPos });
+const track = (componentId, componentPos) => {
+	fireTracking('oTracking.event', { category: 'page', action: 'scrolldepth', componentId, componentPos });
 }
 
 const scrollHandlerFactory = () => {
@@ -12,10 +12,10 @@ const scrollHandlerFactory = () => {
 	return () => {
 		toArray(document.querySelectorAll('.js-track-scroll-event'))
 			.forEach((component, index) => {
-				const dataTrackable = component.getAttribute('data-trackable');
-				if (component.getBoundingClientRect().top < window.innerHeight && componentsViewed.indexOf(dataTrackable) === -1) {
-					track(dataTrackable, index + 1);
-					componentsViewed.push(dataTrackable);
+				const componentId = component.getAttribute('id');
+				if (component.getBoundingClientRect().top < window.innerHeight && componentsViewed.indexOf(componentId) === -1) {
+					track(componentId, index + 1);
+					componentsViewed.push(componentId);
 				}
 			});
 	};

--- a/config/sections/editors-picks.js
+++ b/config/sections/editors-picks.js
@@ -3,6 +3,7 @@ export default () => ({
 	title: 'Editor\'s Picks',
 	style: 'editors-picks',
 	layoutId: 'editors-picks',
+	trackScrollEvent: true,
 	size: {
 		default: 12
 	},

--- a/config/sections/life-and-arts.js
+++ b/config/sections/life-and-arts.js
@@ -3,6 +3,7 @@ export default () => ({
 	title: 'Life & Arts',
 	style: 'life-and-arts',
 	layoutId: 'featured-section',
+	trackScrollEvent: true,
 	size: {
 		default: 12,
 		M: 4

--- a/config/sections/markets.js
+++ b/config/sections/markets.js
@@ -3,6 +3,7 @@ export default () => ({
 	title: 'Markets',
 	style: 'markets',
 	layoutId: 'featured-section',
+	trackScrollEvent: true,
 	size: {
 		default: 12,
 		M: 4

--- a/config/sections/most-popular.js
+++ b/config/sections/most-popular.js
@@ -105,6 +105,7 @@ export default ({ flags }) => ({
 		]
 	} : null,
 	layoutId: 'most-popular',
+	trackScrollEvent: true,
 	size: {
 		default: 12
 	},

--- a/config/sections/myft.js
+++ b/config/sections/myft.js
@@ -3,6 +3,7 @@ export default () => ({
 	title: '<a href="/myft" class="section-meta__link section-meta__link--myft-logo" data-trackable="logo-link"><span class="section-meta__myft-icon">myFT</span></a>',
 	style: 'myft',
 	layoutId: 'myft',
+	trackScrollEvent: true,
 	size: {
 		default: 12
 	},

--- a/config/sections/opinion.js
+++ b/config/sections/opinion.js
@@ -3,6 +3,7 @@ export default () => ({
 	title: 'Opinion',
 	style: 'opinion',
 	layoutId: 'opinion',
+	trackScrollEvent: true,
 	size: {
 		default: 12
 	},

--- a/config/sections/technology.js
+++ b/config/sections/technology.js
@@ -3,6 +3,7 @@ export default () => ({
 	title: 'Technology',
 	style: 'technology',
 	layoutId: 'featured-section',
+	trackScrollEvent: true,
 	size: {
 		default: 12,
 		M: 4

--- a/config/sections/top-stories.js
+++ b/config/sections/top-stories.js
@@ -32,6 +32,7 @@ export default ({ content, flags }) => ({
 	isTab: true,
 	layoutId: getLayout(content, flags),
 	trackable: getLayout(content, flags),
+	trackScrollEvent: true,
 	size: {
 		default: 12
 	},

--- a/config/sections/videos.js
+++ b/config/sections/videos.js
@@ -4,6 +4,7 @@ export default () => ({
 	title: 'Video',
 	style: 'video',
 	layoutId: 'video',
+	trackScrollEvent: true,
 	size: {
 		default: 12
 	},

--- a/shared/components/section/section.js
+++ b/shared/components/section/section.js
@@ -25,8 +25,7 @@ export default class Section extends Component {
 		}
 		const sectionClasses = classify([
 			'o-grid-row',
-			'section--' + this.props.style,
-			this.props.trackScrollEvent ? 'js-track-scroll-event' : ''
+			'section--' + this.props.style
 		]);
 		const sectionContentClasses = classify([
 			'section__column',

--- a/shared/components/section/section.js
+++ b/shared/components/section/section.js
@@ -25,7 +25,6 @@ export default class Section extends Component {
 		}
 		const sectionClasses = classify([
 			'o-grid-row',
-			'section',
 			'section--' + this.props.style,
 			this.props.trackScrollEvent ? 'js-track-scroll-event' : ''
 		]);

--- a/shared/components/section/section.js
+++ b/shared/components/section/section.js
@@ -25,7 +25,7 @@ export default class Section extends Component {
 		}
 		const sectionClasses = classify([
 			'o-grid-row',
-			'section--' + this.props.style
+			this.props.style ? 'section--' + this.props.style : ''
 		]);
 		const sectionContentClasses = classify([
 			'section__column',

--- a/shared/components/section/section.js
+++ b/shared/components/section/section.js
@@ -23,12 +23,17 @@ export default class Section extends Component {
 		if (this.props.dynamicContent && this.props.dynamicContent.selected !== 'initial') {
 			trackable += ` | alternate-source | ${getSelectedTitle(this.props.dynamicContent)}`
 		}
+		const sectionClasses = classify([
+			'o-grid-row',
+			'section',
+			'section--' + this.props.style,
+			this.props.trackScrollEvent ? 'js-track-scroll-event' : ''
+		]);
 		const sectionContentClasses = classify([
 			'section__column',
 			'section__column--content',
 			this.props.isTab ? 'o-tabs__tabpanel' : ''
 		]);
-
 		const sectionAsideClasses = classify([
 			'section__column',
 			'section__column--sidebar',
@@ -36,7 +41,7 @@ export default class Section extends Component {
 		]);
 
 		return (
-			<section className={`o-grid-row section section--${this.props.style}`} data-trackable={trackable}>
+			<section className={sectionClasses} data-trackable={trackable}>
 				{
 					cols.meta ?
 						<div data-o-grid-colspan={colspan(cols.meta)} className="section__column section__column--meta">

--- a/test/server/shared/section/section.test.js
+++ b/test/server/shared/section/section.test.js
@@ -15,24 +15,25 @@ const SectionNode = proxyquire('../../../../shared/components/section/section', 
 describe('SectionNode', () => {
 
 	const props = {
+		id: 'section-node-id',
+		style: 'section-node-style',
 		cols: {
 			content: { },
 			sidebar: { }
 		},
-		id: 'sectionNodeId',
 		sidebarComponent: {
-			id: 'sidebarComponentId',
+			id: 'sidebar-component-id',
 			component: stub
 		}
 	}
 
-	it('should render section component with "section" class if correct data provided', () => {
+	it('should render section component with "section--section-node-style" class if correct data provided', () => {
 		const section = TestUtils.renderIntoDocument(
 			<SectionNode
 			content={ { main: [''] } }
 			{...props} />
 		);
-		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section')).should.not.throw();
+		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section--section-node-style')).should.not.throw();
 	});
 
 	it('should not render section component if no content provided', () => {
@@ -41,7 +42,7 @@ describe('SectionNode', () => {
 			content={ null }
 			{...props} />
 		);
-		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section')).should.throw();
+		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section--section-node-style')).should.throw();
 	});
 
 	it('should not render section component if content without main attribute provided', () => {
@@ -50,7 +51,7 @@ describe('SectionNode', () => {
 			content={ { main: null } }
 			{...props} />
 		);
-		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section')).should.throw();
+		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section--section-node-style')).should.throw();
 	});
 
 	it('should not render section component if content with empty main attribute provided', () => {
@@ -59,6 +60,6 @@ describe('SectionNode', () => {
 			content={ { main: [] } }
 			{...props} />
 		);
-		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section')).should.throw();
+		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section--section-node-style')).should.throw();
 	});
 });

--- a/test/server/shared/section/section.test.js
+++ b/test/server/shared/section/section.test.js
@@ -27,13 +27,13 @@ describe('SectionNode', () => {
 		}
 	}
 
-	it('should render section component with "section--section-node-style" class if correct data provided', () => {
+	it('should render section component if correct data provided', () => {
 		const section = TestUtils.renderIntoDocument(
 			<SectionNode
 			content={ { main: [''] } }
 			{...props} />
 		);
-		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section--section-node-style')).should.not.throw();
+		(() => TestUtils.findRenderedDOMComponentWithTag(section, 'section')).should.not.throw();
 	});
 
 	it('should not render section component if no content provided', () => {
@@ -42,7 +42,7 @@ describe('SectionNode', () => {
 			content={ null }
 			{...props} />
 		);
-		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section--section-node-style')).should.throw();
+		(() => TestUtils.findRenderedDOMComponentWithTag(section, 'section')).should.throw();
 	});
 
 	it('should not render section component if content without main attribute provided', () => {
@@ -51,7 +51,7 @@ describe('SectionNode', () => {
 			content={ { main: null } }
 			{...props} />
 		);
-		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section--section-node-style')).should.throw();
+		(() => TestUtils.findRenderedDOMComponentWithTag(section, 'section')).should.throw();
 	});
 
 	it('should not render section component if content with empty main attribute provided', () => {
@@ -60,6 +60,15 @@ describe('SectionNode', () => {
 			content={ { main: [] } }
 			{...props} />
 		);
-		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section--section-node-style')).should.throw();
+		(() => TestUtils.findRenderedDOMComponentWithTag(section, 'section')).should.throw();
+	});
+
+	it('should render section component with "section--section-node-style" class if correct data provided', () => {
+		const section = TestUtils.renderIntoDocument(
+			<SectionNode
+			content={ { main: [''] } }
+			{...props} />
+		);
+		(() => TestUtils.findRenderedDOMComponentWithClass(section, 'section--section-node-style')).should.not.throw();
 	});
 });

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -41,7 +41,7 @@
 	-->
 	<div class="o-grid-row">
 	{{#each sections}}
-		<div id="{{id}}" {{#if trackScrollEvent}}class="js-track-scroll-event"{{/if}} data-o-grid-colspan="{{colspan size}}">{{#unless isClient}}{{{reactRenderToString ../Section spread=@this}}}{{/unless}}</div>
+		<div id="{{id}}"{{#if trackScrollEvent}} class="js-track-scroll-event" {{/if}}data-o-grid-colspan="{{colspan size}}">{{#unless isClient}}{{{reactRenderToString ../Section spread=@this}}}{{/unless}}</div>
 	{{/each}}
 	</div>
 </section>

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -41,7 +41,7 @@
 	-->
 	<div class="o-grid-row">
 	{{#each sections}}
-		<div id="{{id}}" data-o-grid-colspan="{{colspan size}}">{{#unless isClient}}{{{reactRenderToString ../Section spread=@this}}}{{/unless}}</div>
+		<div id="{{id}}" {{#if trackScrollEvent}}class="js-track-scroll-event"{{/if}} data-o-grid-colspan="{{colspan size}}">{{#unless isClient}}{{{reactRenderToString ../Section spread=@this}}}{{/unless}}</div>
 	{{/each}}
 	</div>
 </section>


### PR DESCRIPTION
cc @ironsidevsquincy @adambraimbridge 

For scroll depth graphs it seems the only data needed is the `data-trackable` value of the sections (i.e. `opinion`, `editors-picks`, etc.) so have dispensed with sending results from `getDomPath` function (which do not seem to apply in any case given the sections have no ancestors with a `data-trackable` property).

Will continue to send `componentPos` should sections ever be re-ordered and we need to know when, e.g. opinion is at a given position in the ordering of sections.

`js-track-scroll-event` property is added to the parent div of the section so that we can easily acquire the `id` value; in the case of the top-stories variations, this will allow us to consistently track the section as `top-stories` (rather than, e.g. `top-stories-picture-story`).