### PR TITLE
Use updated quote icon

### DIFF
--- a/shared/components/card/tag/_tag.scss
+++ b/shared/components/card/tag/_tag.scss
@@ -63,14 +63,14 @@
 	background-color: getColor('pink');
 
 	.card__tag--authors & {
-		@include nextIcon(pullquote, getColor('claret'), 16, $icon-only: true);
+		@include nextIcon('quote', getColor('claret'), 16, $icon-only: true);
 		background-repeat: no-repeat;
 		background-position: 0 50%;
 		background-size: 16px 12px;
 		padding-left: 21px;
 
 		&:hover {
-			@include nextIcon(pullquote, getColor('cold-1'), 16, $icon-only: true);
+			@include nextIcon('quote', getColor('cold-1'), 16, $icon-only: true);
 		}
 	}
 


### PR DESCRIPTION
Fixes conversion to png (for IE8)

### Before

![screen shot 2016-02-24 at 17 42 54](https://cloud.githubusercontent.com/assets/74132/13294919/2b32f116-db1e-11e5-9190-906809ccc4fc.jpeg)

### After

![screen shot 2016-02-24 at 17 42 49](https://cloud.githubusercontent.com/assets/74132/13294923/2fe50794-db1e-11e5-858a-bcf830016507.jpeg)
