### PR TITLE
Page menu for FastFT journey

### DIFF
--- a/client/components/page-menu/_page-menu.scss
+++ b/client/components/page-menu/_page-menu.scss
@@ -1,0 +1,49 @@
+.page-menu {
+	background-color: getColor('warm-1');
+	border-bottom: 1px getColor('grey-tint1') solid;
+
+	@include oGridRespondTo(L) {
+		display: none;
+	}
+}
+
+.page-menu__items {
+	max-width: oGridGetMaxWidthForLayout('S');
+	margin: 0 auto;
+}
+
+.page-menu__item {
+	float: left;
+	width: 50%;
+	position: relative;
+	text-align: center;
+	margin: 0;
+	border-bottom: 0;
+	font-size: 16px;
+	line-height: 32px;
+	font-weight: oFontsWeight(medium);
+	color: getColor('grey-tint3');
+
+	&:after {
+		position: absolute;
+		left: 0;
+		bottom: 0;
+		content: '';
+		width: 100%;
+		height: 5px;
+	}
+
+	&:hover,
+	&:focus {
+		&:after {
+			background-color: getColor('grey-tint3');
+		}
+	}
+
+	&.page-menu__item--current-page {
+		color: inherit;
+		&:after {
+			background-color: oColorsGetColorFor(fast-ft, text);
+		}
+	}
+}

--- a/client/ie8.scss
+++ b/client/ie8.scss
@@ -37,6 +37,10 @@ $o-grid-ie8-rules: 'only';
 	display: none;
 }
 
+.page-menu {
+	display: none;
+}
+
 // Prevents background being hidden in right x-overflow area when browser window narrower than 1220px
 .o-header-before,
 .o-header,

--- a/client/main.scss
+++ b/client/main.scss
@@ -22,6 +22,7 @@ $o-grid-ie8-rules: false;
 @import "colors";
 
 @import "components/header-tabs/header-tabs";
+@import "components/page-menu/page-menu";
 @import "components/video/video";
 @import "components/markets-data/markets-data";
 @import "components/highlight-dom-path/highlight-dom-path";

--- a/views/front-page.html
+++ b/views/front-page.html
@@ -6,7 +6,12 @@
 	<meta name="dfp_zone" content="{{region}}" />
 {{/defineBlock}}
 
-{{> header-tabs newsTabTitle="Top Stories" fastFTPath=flags.frontPageFastFTJourney}}
+{{#if flags.frontPageFastFTJourney}}
+	{{> page-menu}}
+{{else}}
+	{{> header-tabs}}
+{{/if}}
+
 <section
 	id="main-body"
 	class="main-body o-grid-container n-util-clearfix">

--- a/views/partials/header-tabs.html
+++ b/views/partials/header-tabs.html
@@ -2,11 +2,11 @@
 	<ul data-o-component="o-tabs" class="header-tabs o-grid-row" role="tablist" data-trackable="header-tabs">
 		<li class="header-tab" role="tab" data-o-grid-colspan="6" aria-selected="true">
 			<a class="header-tab__link" href="#top-stories-section-content" data-trackable="news-tab">
-				<span class="header-tab__link__text">{{newsTabTitle}}</span>
+				<span class="header-tab__link__text">Top Stories</span>
 			</a>
 		</li>
 		<li class="header-tab" role="tab" data-o-grid-colspan="6">
-			<a class="header-tab__link" href="{{#if fastFTPath}}fastft{{else}}#top-stories-section-aside{{/if}}" data-trackable="fastft-tab">
+			<a class="header-tab__link" href="#top-stories-section-aside" data-trackable="fastft-tab">
 				<span class="header-tab__link__text">fastFT</span>
 			</a>
 		</li>

--- a/views/partials/page-menu.html
+++ b/views/partials/page-menu.html
@@ -1,0 +1,6 @@
+<div class="page-menu" data-trackable="page-menu" role="presentation" aria-hidden="true">
+	<div class="page-menu__items n-util-clearfix">
+		<p class="page-menu__item page-menu__item--current-page">Top Stories</p>
+		<a class="page-menu__item" href="fastft" data-trackable="fastft-link">fastFT</a>
+	</div>
+</div>


### PR DESCRIPTION
cc @ironsidevsquincy 

Corresponding PR relating to stream page implementation:
https://github.com/Financial-Times/next-stream-page/pull/938

##### Page menu:
![frontpage](https://cloud.githubusercontent.com/assets/10484515/13474711/2d82c358-e0b7-11e5-99b8-3bc31ad9951b.png)

##### Page menu displaying fastFT link hover state:
![frontpage hover state](https://cloud.githubusercontent.com/assets/10484515/13474719/31a9cc9c-e0b7-11e5-8d34-2a766e700d3d.png)