### PR TITLE
Markets Data: accessible 'market down' text colour

### DIFF
--- a/client/_colors.scss
+++ b/client/_colors.scss
@@ -5,11 +5,16 @@
 @include oColorsSetColor('liveblog-amber', #fd9d00);
 @include oColorsSetColor('market-up', #9cd321);
 @include oColorsSetColor('market-down', #ee2f01);
+@include oColorsSetColor('market-down-text', #ff767c);
 @include oColorsSetColor('card-rule', #f0e4d5);
 @include oColorsSetColor('column-rule', #e1c9b2);
 
 // use cases
 @include oColorsSetUseCase(dark-bg, background, 'cold-1');
+@include oColorsSetUseCase(market-up, border, 'market-up');
+@include oColorsSetUseCase(market-up, text, 'market-up');
+@include oColorsSetUseCase(market-down, border, 'market-down');
+@include oColorsSetUseCase(market-down, text, 'market-down-text');
 @include oColorsSetUseCase(fast-ft, text, 'fastft-brand');
 @include oColorsSetUseCase(fast-ft, background, 'fastft-highlight');
 @include oColorsSetUseCase(related-story, background, 'pink-tint1');

--- a/client/components/markets-data/_markets-data.scss
+++ b/client/components/markets-data/_markets-data.scss
@@ -58,22 +58,12 @@
 	padding: 1px 5px;
 }
 .markets-data__item__change--up {
-	color: getColor('market-up');
-	border-color: getColor('market-up');
-
-	.markets-data__item__link:hover &,
-	.markets-data__item__link:focus & {
-		background-color: rgba(getColor('market-up'), 0.4);
-	}
+	@include oColorsFor(market-up, border);
+	@include oColorsFor(market-up, text);
 }
 .markets-data__item__change--down {
-	color: getColor('market-down');
-	border-color: getColor('market-down');
-
-	.markets-data__item__link:hover &,
-	.markets-data__item__link:focus & {
-		background-color: rgba(getColor('market-down'), 0.4);
-	}
+	@include oColorsFor(market-down, border);
+	@include oColorsFor(market-down, text);
 }
 .markets-data__link {
 	@include oTypographySans(s);


### PR DESCRIPTION
Also remove hover effect

![screen shot 2016-03-03 at 16 59 56](https://cloud.githubusercontent.com/assets/74132/13502088/6212c168-e161-11e5-9c2b-596c6bf527bd.jpeg)
