### PR TITLE
Remove: fastFT colors & use cases (import from next-sass-setup)

### DIFF
--- a/client/_colors.scss
+++ b/client/_colors.scss
@@ -1,7 +1,5 @@
 // TODO get these back into o-colors on the next branch
 // colours
-@include oColorsSetColor('fastft-brand', #cf191d);
-@include oColorsSetColor('fastft-highlight', #f5dfd9);
 @include oColorsSetColor('liveblog-amber', #fd9d00);
 @include oColorsSetColor('market-up', #9cd321);
 @include oColorsSetColor('market-down', #ee2f01);
@@ -15,8 +13,6 @@
 @include oColorsSetUseCase(market-up, text, 'market-up');
 @include oColorsSetUseCase(market-down, border, 'market-down');
 @include oColorsSetUseCase(market-down, text, 'market-down-text');
-@include oColorsSetUseCase(fast-ft, text, 'fastft-brand');
-@include oColorsSetUseCase(fast-ft, background, 'fastft-highlight');
 @include oColorsSetUseCase(related-story, background, 'pink-tint1');
 @include oColorsSetUseCase(card, border, 'card-rule');
 @include oColorsSetUseCase(card-picture-story, background, 'pink-tint2');


### PR DESCRIPTION
cc @ironsidevsquincy 

Added to `next-sass-setup` in this PR: https://github.com/Financial-Times/next-sass-setup/pull/116/files