### PR TITLE
Apply: Border use case for fastFT color for page menu styling

### DIFF
--- a/client/components/page-menu/_page-menu.scss
+++ b/client/components/page-menu/_page-menu.scss
@@ -43,7 +43,7 @@
 	&.page-menu__item--current-page {
 		color: inherit;
 		&:after {
-			background-color: oColorsGetColorFor(fast-ft, text);
+			background-color: oColorsGetColorFor(fast-ft, border);
 		}
 	}
 }


### PR DESCRIPTION
cc @ironsidevsquincy 