### PR TITLE
Remove: Unwanted block in subnav

### DIFF
--- a/shared/components/column/_column.scss
+++ b/shared/components/column/_column.scss
@@ -11,7 +11,7 @@
 		top: oGridGutter() / 2;
 		bottom: oGridGutter() / 2;
 		background-color: oColorsGetColorFor(column, border);
-		z-index: 1;
+		z-index: 0;
 
 		@include oGridRespondTo(M) {
 			left: floor(oGridGutter(M) / 2);
@@ -26,7 +26,7 @@
 			top: oGridGutter() * 2;
 			bottom: oGridGutter();
 			background-color: oColorsGetColorFor(card, border);
-			z-index: 0;
+			z-index: -1;
 
 			@include oGridRespondTo(M) {
 				top: oGridGutter() + oGridGutter(M);

--- a/shared/components/section/_section.scss
+++ b/shared/components/section/_section.scss
@@ -45,7 +45,7 @@
 			height: 1px;
 			left: 0;
 			top: oGridGutter() / 2;
-			z-index: 2;
+			z-index: 1;
 
 			@include oGridRespondTo(M) {
 				top: floor(oGridGutter(M) / 2);


### PR DESCRIPTION
cc @ironsidevsquincy 

Fixes this [issue](https://jira.ft.com/browse/NFT-352) in short-term.

However, should the separating border have a gap between the top of the cards and where the border starts, as it does at the bottom of the cards (see images)? If so, the issue could potentially be fixed without amending the z-indexes in `_column.scss` by adding 15px to the border's [top position](https://github.com/Financial-Times/next-front-page/blob/master/shared/components/column/_column.scss#L18) (although not sure how to do that in a (non-hacky) way that adheres to `oGridGutter` logic).

Long-term solutions:-
- Applying margin-top to entire column rather than the individual cards (but I remember us doing this for one of the Top Stories layouts and having to abandon for a reason I now can't remember, and it is quite an overhaul).

- @keirog has also started some z-index logic management in [`next-sass-setup`](https://github.com/Financial-Times/next-sass-setup/blob/master/_z-indexes.scss)

But will this do it in the meantime?

##### Top of cards
![screen shot 2016-03-07 at 14 32 23](https://cloud.githubusercontent.com/assets/10484515/13572301/7e5db824-e471-11e5-9d76-9f5f36df4da9.png)

##### Bottom of cards
![screen shot 2016-03-07 at 14 32 41](https://cloud.githubusercontent.com/assets/10484515/13572304/8283e284-e471-11e5-91cb-13d926b09087.png)