### PR TITLE
hide overflow of images with unexpected ratios

### DIFF
--- a/shared/components/card/image/_image.scss
+++ b/shared/components/card/image/_image.scss
@@ -74,6 +74,7 @@
 .card__picture {
 	display: block;
 	max-width: 100%;
+	overflow: hidden;
 
 	.card__image-link--headshot & {
 		width: 56.25%;


### PR DESCRIPTION
@ironsidevsquincy @andygout 

In response to this:

![image](https://cloud.githubusercontent.com/assets/4750238/13634782/c460709e-e5ef-11e5-9f59-20a7404d5d6d.png)
