### PR TITLE
Allow bower/node module linking

### DIFF
--- a/server/setup.js
+++ b/server/setup.js
@@ -3,15 +3,15 @@ const es6Modules = ['@financial-times/n-card', 'n-image', 'next-myft-ui'];
 
 require('babel-register')({
 	plugins: [
-		'add-module-exports',
-		'array-includes',
-		'transform-es2015-destructuring',
-		'transform-es2015-modules-commonjs',
-		'transform-es2015-parameters',
-		'transform-es2015-spread'
+		require.resolve('babel-plugin-add-module-exports'),
+		require.resolve('babel-plugin-array-includes'),
+		require.resolve('babel-plugin-transform-es2015-destructuring'),
+		require.resolve('babel-plugin-transform-es2015-modules-commonjs'),
+		require.resolve('babel-plugin-transform-es2015-parameters'),
+		require.resolve('babel-plugin-transform-es2015-spread')
 	],
 	presets: [
-		'react'
+		require.resolve('babel-preset-react')
 	],
 	ignore: filename =>
 		filename.includes('/node_modules/') && !es6Modules.some(module => filename.includes(`/node_modules/${module}`))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
 		loaders: [
 			{
 				test: /\.js$/,
-				loader: 'babel',
+				loader: require.resolve('babel-loader'),
 				include: [
 					/bower_components/,
 					/n-card/,
@@ -23,11 +23,15 @@ module.exports = {
 				],
 				query: {
 					cacheDirectory: true,
-					presets: (require('./package.json').dependencies.react ? ['react', 'es2015'] : ['es2015']),
+					presets: (
+						require('./package.json').dependencies.react ?
+							[require.resolve('babel-preset-react'), require.resolve('babel-preset-es2015')] :
+							[require.resolve('babel-preset-es2015')]
+					),
 					plugins: [
-						'add-module-exports',
-						'transform-runtime',
-						['transform-es2015-classes', { loose: true }]
+						require.resolve('babel-plugin-add-module-exports'),
+						require.resolve('babel-plugin-transform-runtime'),
+						[require.resolve('babel-plugin-transform-es2015-classes'), { loose: true }]
 					]
 				}
 			},
@@ -70,7 +74,8 @@ module.exports = {
 	),
 	resolve: {
 		root: [
-			path.join(__dirname, 'bower_components')
+			path.join(__dirname, 'bower_components'),
+			path.join(__dirname, 'node_modules')
 		]
 	}
 };


### PR DESCRIPTION
Odd issue in babel 6 where is borks when linking modules

This fixes it (see http://stackoverflow.com/questions/34574403/how-to-set-resolve-for-babel-loader-presets/)

@adgad 