### PR TITLE
Fix Firefox/IE issue with overflowing image/text

### DIFF
--- a/shared/components/myft-promo/_myft-promo.scss
+++ b/shared/components/myft-promo/_myft-promo.scss
@@ -1,7 +1,9 @@
 .myft-promo {
 	align-self: center;
-	padding: 20px;
+	box-sizing: border-box;
+	padding: 15px 30px;
 	text-align: center;
+	width: 100%;
 }
 
 .myft-promo__image {
@@ -11,7 +13,7 @@
 .myft-promo__description {
 	@include oTypographySansBold(m);
 	color: getColor('cold-1');
-	margin: 10px 35px 15px;
+	margin: 10px 0 15px;
 }
 
 .myft-promo__link-wrapper {


### PR DESCRIPTION
Before | After
---|---
![before](https://cloud.githubusercontent.com/assets/150157/13987827/426f6b4a-f101-11e5-84a3-77c093596b2f.png) | ![after](https://cloud.githubusercontent.com/assets/150157/13987828/462b1202-f101-11e5-8bce-fdc3528b4720.png)
