### PR TITLE
Stops babel sending polyfill's

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
 					),
 					plugins: [
 						require.resolve('babel-plugin-add-module-exports'),
-						require.resolve('babel-plugin-transform-runtime'),
+						[require.resolve('babel-plugin-transform-runtime'), { polyfill: false }],
 						[require.resolve('babel-plugin-transform-es2015-classes'), { loose: true }]
 					]
 				}


### PR DESCRIPTION
We use the FT polyfill service so using the babel polyfill's causes
duplication.

I have tested one various devices and and browsers and haven't seen anything break or console errors. I have also grep'ed the code base for use of stuff like `symbol` and came across nothing but there might be some I have missed.

Would be nice to get some testing / feedback with people who know the product better maybe @ironsidevsquincy or @andygout ?