### PR TITLE
Changes how the section titles are hidden

### DIFF
--- a/shared/components/section/meta/meta.js
+++ b/shared/components/section/meta/meta.js
@@ -2,12 +2,8 @@ import React, { Component } from 'react';
 
 export default class extends Component {
 	render () {
-		let metaClass = 'section-meta';
-		if (this.props.isHidden) {
-			metaClass += ' n-util-visually-hidden';
-		}
 		return (
-			<div className={metaClass}>
+			<div className="section-meta">
 				<h2 className="section-meta__title" dangerouslySetInnerHTML={{ __html: this.props.title }} />
 			</div>
 		);

--- a/shared/components/section/section.js
+++ b/shared/components/section/section.js
@@ -33,12 +33,18 @@ export default class extends Component {
 			this.props.sidebarComponent && this.props.sidebarComponent.hideUntilDesktop ? 'section__column--hide-until-l' : ''
 		]);
 
+		const sectionMetaClasses = classify([
+			'section__column',
+			'section__column--meta',
+			this.props.cols.meta && this.props.cols.meta.hide ? 'n-util-visually-hidden' : ''
+		]);
+
 		return (
 			<section className={sectionClasses} data-trackable={trackable}>
 				{
 					cols.meta ?
-						<div data-o-grid-colspan={colspan(cols.meta)} className="section__column section__column--meta">
-							<SectionMeta title={this.props.title} isHidden={this.props.cols.meta.hide} />
+						<div data-o-grid-colspan={colspan(cols.meta)} className={sectionMetaClasses}>
+							<SectionMeta title={this.props.title} />
 						</div> :
 						null
 				}


### PR DESCRIPTION
Prevents extra spacing appearing when a title is hidden.

It also means the classes are applied in a similar way to elsewhere
within the section.