### PR TITLE
Featured section layout (homepage audit)

### DIFF
--- a/config/layouts/featured-section-new.js
+++ b/config/layouts/featured-section-new.js
@@ -26,7 +26,7 @@ export default [
 				components: [
 					{
 						type: Content,
-						size: 'small',
+						size: 'medium',
 						showStandfirst: true
 					},
 					{

--- a/config/layouts/featured-section-new.js
+++ b/config/layouts/featured-section-new.js
@@ -1,0 +1,44 @@
+import Row from '../../shared/components/row/row';
+import Column from '../../shared/components/column/column';
+import Content from '../../shared/components/content/content';
+
+export default [
+	{
+		type: Row,
+		components: [
+			{
+				type: Column,
+				colspan: { default: 6 },
+				components: [
+					{
+						type: Content,
+						size: 'large',
+						showStandfirst: true,
+						image: {
+							sizes: { default: 210, s: 315, m: 199, l: 259, xl: 322 }
+						}
+					}
+				]
+			},
+			{
+				type: Column,
+				colspan: { default: 6 },
+				components: [
+					{
+						type: Content,
+						size: 'small',
+						showStandfirst: true
+					},
+					{
+						type: Content,
+						size: 'small'
+					},
+					{
+						type: Content,
+						size: 'small'
+					}
+				]
+			}
+		]
+	}
+];

--- a/config/layouts/featured-section-new.js
+++ b/config/layouts/featured-section-new.js
@@ -8,21 +8,22 @@ export default [
 		components: [
 			{
 				type: Column,
-				colspan: { default: 12, S: 6 },
+				colspan: { default: 12, XL: 6 },
 				components: [
 					{
 						type: Content,
 						size: 'large',
 						showStandfirst: true,
 						image: {
-							sizes: { default: 449, s: 315, m: 199, l: 259, xl: 322 }
+							position: { S: 'left', XL: 'bottom' },
+							sizes: { default: 449, s: 264, m: 173, l: 221, xl: 322 }
 						}
 					}
 				]
 			},
 			{
 				type: Column,
-				colspan: { default: 12, S: 6 },
+				colspan: { default: 12, XL: 6 },
 				components: [
 					{
 						type: Content,

--- a/config/layouts/featured-section-new.js
+++ b/config/layouts/featured-section-new.js
@@ -8,21 +8,21 @@ export default [
 		components: [
 			{
 				type: Column,
-				colspan: { default: 6 },
+				colspan: { default: 12, S: 6 },
 				components: [
 					{
 						type: Content,
 						size: 'large',
 						showStandfirst: true,
 						image: {
-							sizes: { default: 210, s: 315, m: 199, l: 259, xl: 322 }
+							sizes: { default: 449, s: 315, m: 199, l: 259, xl: 322 }
 						}
 					}
 				]
 			},
 			{
 				type: Column,
-				colspan: { default: 6 },
+				colspan: { default: 12, S: 6 },
 				components: [
 					{
 						type: Content,

--- a/config/layouts/index.js
+++ b/config/layouts/index.js
@@ -1,6 +1,7 @@
 import editorsPicksLayout from './editors-picks';
 import editorsPicksNewLayout from './editors-picks-new';
 import featuredSectionLayout from './featured-section';
+import featuredSectionNewLayout from './featured-section-new';
 import mostPopularLayout from './most-popular';
 import myftLayout from './myft';
 import midPageAdvertLayout from './mid-page-advert';
@@ -20,6 +21,7 @@ export default {
 	'editors-picks': editorsPicksLayout,
 	'editors-picks-new': editorsPicksNewLayout,
 	'featured-section': featuredSectionLayout,
+	'featured-section-new': featuredSectionNewLayout,
 	'most-popular': mostPopularLayout,
 	'myft': myftLayout,
 	'mid-page-advert': midPageAdvertLayout,

--- a/config/pages.js
+++ b/config/pages.js
@@ -23,7 +23,9 @@ export default (pageId, data, flags) => {
 	// NOTE: need to copy array, so we don't keep inserting the same things into it (immutable FTW)
 	let page = pages[pageId].slice();
 	if (pageId === 'front-page' && flags.frontPageNewLayout) {
-		page = page.map(section => section === 'top-stories' ? 'top-stories-new' : section);
+		page = page
+			.map(section => section === 'top-stories' ? 'top-stories-new' : section)
+			.filter(section => section !== 'life-and-arts');
 	}
 
 	return page.map(sectionId => getSection(sectionId, sectionsData[sectionId], flags));

--- a/config/queries.js
+++ b/config/queries.js
@@ -163,14 +163,14 @@ const frontPage = (region) => (`
 			... OpinionData
 		}
 		technology {
-			items(limit: 2, genres: ["analysis", "comment"]) {
+			items(limit: 4, genres: ["analysis", "comment"]) {
 				... Basic
 				... Extended
 				... OpinionData
 			}
 		}
 		markets {
-			items(limit: 2, genres: ["analysis", "comment"]) {
+			items(limit: 4, genres: ["analysis", "comment"]) {
 				... Basic
 				... Extended
 				... OpinionData

--- a/config/sections/markets.js
+++ b/config/sections/markets.js
@@ -1,12 +1,12 @@
-export default () => ({
+export default ({ flags }) => ({
 	id: 'markets',
 	title: 'Markets',
 	style: 'markets',
-	layoutId: 'featured-section',
+	layoutId: flags.frontPageNewLayout ? 'featured-section-new' : 'featured-section',
 	trackScrollEvent: true,
 	size: {
 		default: 12,
-		M: 4
+		M: flags.frontPageNewLayout ? 6 : 4,
 	},
 	cols: {
 		meta: {

--- a/config/sections/markets.js
+++ b/config/sections/markets.js
@@ -1,6 +1,6 @@
 export default ({ flags }) => ({
 	id: 'markets',
-	title: 'Markets',
+	title: flags.frontPageNewLayout ? 'Markets News' : 'Markets',
 	style: 'markets',
 	layoutId: flags.frontPageNewLayout ? 'featured-section-new' : 'featured-section',
 	trackScrollEvent: true,

--- a/config/sections/technology.js
+++ b/config/sections/technology.js
@@ -1,12 +1,12 @@
-export default () => ({
+export default ({ flags }) => ({
 	id: 'technology',
 	title: 'Technology',
 	style: 'technology',
-	layoutId: 'featured-section',
+	layoutId: flags.frontPageNewLayout ? 'featured-section-new' : 'featured-section',
 	trackScrollEvent: true,
 	size: {
 		default: 12,
-		M: 4
+		M: flags.frontPageNewLayout ? 6 : 4,
 	},
 	cols: {
 		meta: {


### PR DESCRIPTION
cc @ironsidevsquincy 

N.B. Before going live we must first speak to Editorial to ensure that at least four stories in the 'analysis' or 'comment' genre are available (per section: Technology/Markets News/Life & Arts), as there have been instances in the dev process in which there are only two (the current requirement).

##### default (Technology)
![default tech](https://cloud.githubusercontent.com/assets/10484515/14212206/a73678be-f829-11e5-86a5-13d4900e6017.png)

##### default (Markets News)
![default markets](https://cloud.githubusercontent.com/assets/10484515/14212208/a736c148-f829-11e5-83d7-7dfdd0d83d52.png)

##### S
![s](https://cloud.githubusercontent.com/assets/10484515/14212207/a736367e-f829-11e5-9715-cdb89f213fae.png)

##### M - L
![m-l](https://cloud.githubusercontent.com/assets/10484515/14212209/a73af83a-f829-11e5-91f5-4c265aaf2e87.png)

##### XL - XXL
![xl-xxl](https://cloud.githubusercontent.com/assets/10484515/14212205/a7363926-f829-11e5-985b-c929c3c3feb7.png)

