### PR TITLE
Remove redundant border zeroing

### DIFF
--- a/shared/components/_card.scss
+++ b/shared/components/_card.scss
@@ -1,6 +1,5 @@
 .card {
 	margin-top: oGridGutter();
-	border-bottom-width: 0;
 
 	@include oGridRespondTo(M) {
 		margin-top: oGridGutter(M);


### PR DESCRIPTION
The bottom border has been removed from the default n-card, so we don't need this now. (Also this fixes the missing bottom border in the concept card.)