### PR TITLE
Override the default page background color

### DIFF
--- a/client/main.scss
+++ b/client/main.scss
@@ -14,6 +14,8 @@ $o-grid-start-snappy-mode-at: XXL;
 $o-grid-ie8-rules: false;
 
 @import "n-layout/main";
+//Override the default page background color
+@include oColorsSetUseCase(page, background, 'pink');
 @import 'n-card/main';
 @import 'n-section/main';
 @import "n-message-prompts/main";
@@ -33,7 +35,7 @@ $o-grid-ie8-rules: false;
 @import "../shared/components/main";
 
 html {
-	@include oColorsFor(card, background);
+	@include oColorsFor(page, background);
 	// Prevent navigation menus from creating
 	// extra space on sides of the page
 	overflow-x: auto;

--- a/shared/components/myft-promo/_myft-promo.scss
+++ b/shared/components/myft-promo/_myft-promo.scss
@@ -38,7 +38,7 @@
 }
 
 .card--myft-promo {
-	background: rgba(getColorFor('myft'), 0.1);
-	border-bottom-color: getColorFor('myft');
+	background: mix(getColorFor('myft'), getColorFor('page', background), 10%);
+	border-bottom: 1px solid getColorFor('myft');
 	justify-content: center;
 }


### PR DESCRIPTION
This is so we can use Sass' `mix` function in our components, resulting 
in solid background colors that are visually the same as RGBA-transparent 
colors, without relying on RGBA browser support.