### PR TITLE
Update: Opinion section layout (frontpage audit)

### DIFF
--- a/config/layouts/opinion-new.js
+++ b/config/layouts/opinion-new.js
@@ -18,33 +18,61 @@ export default [
 			},
 			{
 				type: 'Column',
-				colspan: { default: 12, M: 4, L: 3 },
+				colspan: { default: 12, M: 8, L: 6 },
 				components: [
 					{
-						type: 'Content',
-						size: 'medium',
-						showStandfirst: true
+						type: 'Row',
+						components: [
+							{
+								type: 'Column',
+								colspan: { default: 12, M: 6 },
+								components: [
+									{
+										type: 'Content',
+										size: 'medium',
+										showStandfirst: true
+									}
+								]
+							},
+							{
+								type: 'Column',
+								colspan: { default: 12, M: 6 },
+								components: [
+									{
+										type: 'Content',
+										size: 'medium',
+										showStandfirst: true
+									}
+								]
+							}
+						]
 					},
 					{
-						type: 'Content',
-						size: 'medium',
-						showStandfirst: true
-					}
-				]
-			},
-			{
-				type: 'Column',
-				colspan: { default: 12, M: 4, L: 3 },
-				components: [
-					{
-						type: 'Content',
-						size: 'medium',
-						showStandfirst: true
-					},
-					{
-						type: 'Content',
-						size: 'medium',
-						showStandfirst: true
+						type: 'Row',
+						components: [
+							{
+								type: 'Column',
+								colspan: { default: 12, M: 6 },
+								components: [
+									{
+										type: 'Content',
+										size: 'medium',
+										showStandfirst: true
+									}
+								]
+							},
+							{
+								type: 'Column',
+								colspan: { default: 12, M: 6 },
+								components: [
+									{
+										type: 'Content',
+										size: 'medium',
+										showStandfirst: true
+									}
+								]
+							}
+						]
 					}
 				]
 			},


### PR DESCRIPTION
cc @ironsidevsquincy 

Stories 2-5 are now vertically balanced (and as a result stories 3 & 4 have switched position).

Default and S layouts remain the same.

##### From (L - XL):
![from l-xl](https://cloud.githubusercontent.com/assets/10484515/14345061/e9c4eb98-fca2-11e5-98f2-1429a80690fd.png)

##### To (L - XL):
![to l-xl](https://cloud.githubusercontent.com/assets/10484515/14345059/e9c4175e-fca2-11e5-8582-1d6bb92f331d.png)

##### From (M):
![from m](https://cloud.githubusercontent.com/assets/10484515/14345060/e9c49b20-fca2-11e5-92a1-4f549b4366b9.png)

##### To (M):
![to m](https://cloud.githubusercontent.com/assets/10484515/14345058/e9c3f2b0-fca2-11e5-935f-fb7ec87e8ce2.png)