### PR TITLE
Fix: Vertical card rules for big story

### DIFF
--- a/shared/components/_card-ie8.scss
+++ b/shared/components/_card-ie8.scss
@@ -6,5 +6,9 @@
 		top: oGridGutter(M) / 2;
 		bottom: oGridGutter(M) / -2;
 		left: oGridGutter(M) / -2;
+
+		.column--related & {
+			bottom: oGridGutter(M) / 2;
+		}
 	}
 }

--- a/shared/components/_card.scss
+++ b/shared/components/_card.scss
@@ -30,6 +30,10 @@
 			top: oGridGutter(M) / 2;
 			bottom: oGridGutter(M) / -2;
 			left: oGridGutter(M) / -2;
+
+			.column--related & {
+				bottom: oGridGutter(M) / 2;
+			}
 		}
 	}
 


### PR DESCRIPTION
cc @ironsidevsquincy 

Prevents lines from spilling out from bottom of background.

##### From:
![from](https://cloud.githubusercontent.com/assets/10484515/14382030/8dac785e-fd82-11e5-8565-9041f0215eb1.png)

##### To:
![to](https://cloud.githubusercontent.com/assets/10484515/14382031/8dc3173a-fd82-11e5-8a92-b7d69a1f82c6.png)
