### PR TITLE
Use: Specific markets data use case for color

### DIFF
--- a/client/components/markets-data/_markets-data.scss
+++ b/client/components/markets-data/_markets-data.scss
@@ -19,7 +19,7 @@
 .markets-data {
 	padding-top: 10px;
 	padding-bottom: 10px;
-	color: oColorsGetColorFor(page, background);
+	color: getColor('white');
 }
 .markets-data__items {
 	float: left;


### PR DESCRIPTION
cc @ironsidevsquincy 

Will use this specific `markets-data` use-case from `next-sass-setup`: https://github.com/Financial-Times/next-sass-setup/pull/127 given frontpage now overrides the use-case that it previously used: https://github.com/Financial-Times/next-front-page/blob/master/client/main.scss#L18

##### From (note colour of text for 'FTSE 100'):
![from](https://cloud.githubusercontent.com/assets/10484515/14421672/d07cc5cc-ffca-11e5-89c1-0ddca2216756.png)

##### To:
![to](https://cloud.githubusercontent.com/assets/10484515/14421671/d07c1ee2-ffca-11e5-8966-95ffecdb0d5d.png)
