### PR TITLE
Ad transitions and improvements

### DIFF
--- a/client/components/ads/_ads.scss
+++ b/client/components/ads/_ads.scss
@@ -35,7 +35,7 @@ $ad-medium-breakpoint: 760px;
 	height: auto;
 	padding: 0;
 	min-height: calc(100vw * 0.1734); //aspect ratio of responsive creatives
-	@media (max-width: 489px) {
+	@include oGridRespondTo($until: S) {
 		min-height: calc(100vw * 0.481);
 	}
 }

--- a/client/components/ads/_ads.scss
+++ b/client/components/ads/_ads.scss
@@ -10,6 +10,10 @@ $ad-medium-breakpoint: 760px;
 		line-height: 0;
 		white-space: pre;
 		text-align: center;
+
+		&[data-o-ads-loaded="Responsive"] {
+			padding: 0;
+		}
 	}
 }
 
@@ -33,7 +37,6 @@ $ad-medium-breakpoint: 760px;
 
 .advert[data-o-ads-loaded="Responsive"] {
 	height: auto;
-	padding: 0;
 	min-height: calc(100vw * 0.1734); //aspect ratio of responsive creatives
 	@include oGridRespondTo($until: S) {
 		min-height: calc(100vw * 0.481);

--- a/client/components/ads/_ads.scss
+++ b/client/components/ads/_ads.scss
@@ -1,9 +1,16 @@
 // Ad breakpoint where leaderboards start working
 $ad-medium-breakpoint: 760px;
 
+@mixin adWillTransition {
+	will-change: min-height, padding, height;
+	transform: translate3d(0,0,0);
+	transition: height 0.35s ease-in-out, min-height 0.35s ease-in-out, padding 0.35s ease-in-out;
+}
 .above-header-advert {
 	@media (min-width:$ad-medium-breakpoint) {
+		@include adWillTransition();
 		min-height: 90px;
+		height: 90px;
 		display: block;
 		padding: 10px 0;
 		line-height: 0;
@@ -12,15 +19,23 @@ $ad-medium-breakpoint: 760px;
 	}
 
 	&[data-o-ads-loaded="Responsive"] {
+		height: auto;
+		min-height: calc(100vw * 0.1735); //aspect ratio of responsive creatives
 		padding: 0;
 	}
 
+	&[data-o-ads-loaded="Billboard"] {
+		height: 250px;
+	}
+
 }
+
 
 .mid-page-1-advert,
 .mid-page-2-advert {
 	display: block;
 	padding: 10px 0 0;
+	background-color: getColorFor('page', 'background');
 	[data-ads-layout="default"] & {
 		display: none;
 		padding: 0;

--- a/client/components/ads/_ads.scss
+++ b/client/components/ads/_ads.scss
@@ -1,14 +1,8 @@
 // Ad breakpoint where leaderboards start working
 $ad-medium-breakpoint: 760px;
 
-@mixin adWillTransition {
-	will-change: min-height, padding, height;
-	transform: translate3d(0,0,0);
-	transition: height 0.35s ease-in-out, min-height 0.35s ease-in-out, padding 0.35s ease-in-out;
-}
 .above-header-advert {
 	@media (min-width:$ad-medium-breakpoint) {
-		@include adWillTransition();
 		min-height: 90px;
 		height: 90px;
 		display: block;
@@ -17,25 +11,14 @@ $ad-medium-breakpoint: 760px;
 		white-space: pre;
 		text-align: center;
 	}
-
-	&[data-o-ads-loaded="Responsive"] {
-		height: auto;
-		min-height: calc(100vw * 0.1735); //aspect ratio of responsive creatives
-		padding: 0;
-	}
-
-	&[data-o-ads-loaded="Billboard"] {
-		height: 250px;
-	}
-
 }
-
 
 .mid-page-1-advert,
 .mid-page-2-advert {
 	display: block;
+	height: 90px;
+	min-height: 90px;
 	padding: 10px 0 0;
-	background-color: getColorFor('page', 'background');
 	[data-ads-layout="default"] & {
 		display: none;
 		padding: 0;
@@ -46,4 +29,36 @@ $ad-medium-breakpoint: 760px;
 	@media (min-width:$ad-medium-breakpoint) {
 		display: none;
 	}
+}
+
+.advert[data-o-ads-loaded="Responsive"] {
+	height: auto;
+	padding: 0;
+	min-height: calc(100vw * 0.1734); //aspect ratio of responsive creatives
+	@media (max-width: 489px) {
+		min-height: calc(100vw * 0.481);
+	}
+}
+
+.advert[data-o-ads-loaded="MediumRectangle"],
+.advert[data-o-ads-loaded="Billboard"] {
+	height: 250px;
+}
+
+.advert--full-bleed {
+	width: 100vw;
+	margin-left: -10px;
+	@include oGridRespondTo(S) {
+		margin-left: -30px;
+	}
+}
+
+.advert--background {
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAALElEQVQIW2M8d2znf2kJMQZkwPjy3vn/T1+8YkCWAAuCVCFLwAWRJVAEYRIAHZ8dptpqH2wAAAAASUVORK5CYII=) repeat;
+}
+
+.advert--transition {
+	will-change: min-height, padding, height;
+	transform: translate3d(0, 0, 0);
+	transition: height 0.35s ease-in-out, min-height 0.35s ease-in-out, padding 0.35s ease-in-out;
 }

--- a/config/sections/mid-page-advert-1.js
+++ b/config/sections/mid-page-advert-1.js
@@ -1,9 +1,9 @@
-export default () => ({
+export default ({flags}) => ({
 	size: {
 		default: 12
 	},
 	raw: `<div data-trackable="ad"
-		class="mid-page-1-advert o-ads"
+		class="mid-page-1-advert o-ads advert ${flags.adLoadingImprovements ? 'advert--full-bleed advert--transition' : ''}"
 		data-o-ads-name="top-below-header"
 		data-o-ads-targeting="pos=top;"
 		data-o-ads-formats-default="MediumRectangle,Responsive"

--- a/config/sections/mid-page-advert-2.js
+++ b/config/sections/mid-page-advert-2.js
@@ -1,4 +1,4 @@
-export default ({data}) => {
+export default ({flags, data}) => {
 	let desktopAds;
 	switch(data.adsLayout) {
 		case 'non-responsive-1':
@@ -15,7 +15,7 @@ export default ({data}) => {
 			default: 12
 		},
 		raw: `<div data-trackable="ad"
-			class="mid-page-2-advert o-ads"
+			class="mid-page-2-advert o-ads advert ${flags.adLoadingImprovements ? 'advert--full-bleed advert--transition' : ''}"
 			data-o-ads-name="mid"
 			data-o-ads-targeting="pos=mid;"
 			data-o-ads-formats-default="Responsive,MediumRectangle"

--- a/views/partials/ads/top-billboard.html
+++ b/views/partials/ads/top-billboard.html
@@ -1,5 +1,9 @@
 <div
-	class="above-header-advert o-ads o-ads__center"
+{{#if @root.flags.adLoadingImprovements}}
+	class="advert above-header-advert o-ads o-ads__center advert--background advert--transition"
+{{else}}
+	class="advert above-header-advert o-ads o-ads__center"
+{{/if}}
 	data-o-ads-name="top"
 	data-o-ads-targeting="pos=top;"
 	data-o-ads-formats-default="false"

--- a/views/partials/ads/top-superleader.html
+++ b/views/partials/ads/top-superleader.html
@@ -1,5 +1,9 @@
 <div
-	class="above-header-advert o-ads o-ads__center"
+{{#if @root.flags.adLoadingImprovements}}
+	class="advert above-header-advert o-ads o-ads__center advert--background advert--transition"
+{{else}}
+	class="advert above-header-advert o-ads o-ads__center"
+{{/if}}
 	data-o-ads-name="top"
 	data-o-ads-targeting="pos=top;"
 	data-o-ads-formats-default="false"

--- a/views/partials/ads/top.html
+++ b/views/partials/ads/top.html
@@ -1,5 +1,9 @@
 <div
-	class="above-header-advert o-ads o-ads__center"
+{{#if @root.flags.adLoadingImprovements}}
+	class="advert above-header-advert o-ads o-ads__center advert--background advert--transition"
+{{else}}
+	class="advert above-header-advert o-ads o-ads__center"
+{{/if}}
 	data-o-ads-name="top"
 	data-o-ads-targeting="pos=top;"
 	data-o-ads-formats-default="false"


### PR DESCRIPTION
/cc @ironsidevsquincy @VladDubrovskis @andrewgeorgiou1981 @leggsimon 
Various ad proposition improvements behind another flag.

* Transition the ad loading
* Add patterned background on top ad
* Full bleed responsive ad in middle
![ad-loading](https://cloud.githubusercontent.com/assets/1978880/14531653/17f7d26a-0256-11e6-82b7-daff280bcde7.gif)
