### PR TITLE
Add: o-card class to myFT promo box

### DIFF
--- a/shared/components/myft-promo/myft-promo.js
+++ b/shared/components/myft-promo/myft-promo.js
@@ -8,7 +8,7 @@ export default class extends Component {
 		const linkTextPrefix = this.props.isMyftUser ? 'Go to' : 'Take a tour of';
 
 		return (
-			<div className="card card--myft-promo" data-trackable="myft-promo">
+			<div className="card o-card card--myft-promo" data-trackable="myft-promo">
 				<div className="myft-promo">
 					<Image
 						url="https://next-geebee.ft.com/assets/myft-tour/myft-in-situ.png"


### PR DESCRIPTION
cc @ironsidevsquincy 

Required for when `o-card` is used on the frontpage. Has no effect by itself so can be safely merged now in anticipation.