### PR TITLE
Remove `mixin-exists` check

### DIFF
--- a/client/ie8.scss
+++ b/client/ie8.scss
@@ -15,13 +15,10 @@ $o-grid-ie8-rules: 'only';
 
 @import "o-grid/main";
 // Mixins to ease the transition to o-grid v4
-@if not mixin-exists(oGridColumn) {
-	@mixin oGridColumn($args...) {
-		@warn "oGridColumn is deprecated. Please use oGridColspan instead.";
-		@include oGridColspan($args...);
-	}
+@mixin oGridColumn($args...) {
+	@warn "oGridColumn is deprecated. Please use oGridColspan instead.";
+	@include oGridColspan($args...);
 }
-
 
 // Surface current layout (for the JS helper)
 @include oGridSurfaceCurrentLayout;

--- a/client/main.scss
+++ b/client/main.scss
@@ -14,12 +14,13 @@ $o-grid-start-snappy-mode-at: XXL;
 $o-grid-ie8-rules: false;
 
 @import "n-layout/main";
-//Override the default page background color
-@include oColorsSetUseCase(page, background, 'pink');
-@import 'n-section/main';
 @import "n-message-prompts/main";
 @import "n-video/main";
 @import "next-myft-ui/main";
+
+//Override the default page background color
+@include oColorsSetUseCase(page, background, 'pink');
+@import 'n-section/main';
 
 @import "colors";
 @import "functions";


### PR DESCRIPTION
Sass won't let us declare mixins within `@if` anymore (technically we weren't ever supposed to do it, but now it errors).

(The mixin shouldn't already exist for this app anyway, so removing the check should be safe.)