### PR TITLE
Add: Correct focus state color to arrow-up icon on 'back to top' link

### DIFF
--- a/client/components/back-to-top/_back-to-top.scss
+++ b/client/components/back-to-top/_back-to-top.scss
@@ -14,7 +14,8 @@
 			padding-right: 10px;
 		}
 
-		&:hover:before {
+		&:hover:before,
+		&:focus:before {
 			@include nextIcon(arrow-up, getColor('cold-1'), 10, $icon-only: true);
 		}
 	}


### PR DESCRIPTION
cc @ironsidevsquincy 