### PR TITLE
Wrap myFT component in it's own flag

### DIFF
--- a/client/components/myft/myft.js
+++ b/client/components/myft/myft.js
@@ -75,7 +75,7 @@ const handleResponse = (myFtContainerEl, myftClient, flags, response) => {
 
 export default (myftClient, flags) => {
 	const myFtContainerEl = document.getElementById('myft');
-	if (myFtContainerEl && flags.get('myFtApi') && sessionClient.cookie()) {
+	if (myFtContainerEl && flags.get('myFtApi') && flags.get('frontPageMyFtSection') && sessionClient.cookie()) {
 		components.MyftPromo = MyftPromo;
 		sessionClient.uuid()
 			.then(response => {


### PR DESCRIPTION
Currently the `getViewed()` request that the myFT component makes is failing. This is causing issues throughout the stack. Whilst we diagnose the issue further we want to remove the pressure on the DB my disabling the component.